### PR TITLE
Add support for userdata on classic infrastructure

### DIFF
--- a/builder/ibmcloud/classic/client.go
+++ b/builder/ibmcloud/classic/client.go
@@ -49,6 +49,8 @@ type InstanceType struct {
 	BaseImageId            string
 	BaseOsCode             string
 	PublicSecurityGroupIds []int64
+	UserData               []Attribute
+	UserDataCount          uint64
 }
 
 type InstanceReq struct {
@@ -68,6 +70,8 @@ type InstanceReq struct {
 	BlockDeviceTemplateGroup *BlockDeviceTemplateGroup `json:"blockDeviceTemplateGroup,omitempty"`
 	OsReferenceCode          string                    `json:"operatingSystemReferenceCode,omitempty"`
 	SshKeys                  []*SshKey                 `json:"sshKeys,omitempty"`
+	UserData                 []Attribute               `json:"userData,omitempty"`
+	UserDataCount            uint64                    `json:"userDataCount,omitempty"`
 }
 
 type InstanceImage struct {
@@ -126,6 +130,10 @@ type SecurityGroupBindings struct {
 
 type SecurityGroup struct {
 	Id int64 `json:"id,omitempty"`
+}
+
+type Attribute struct {
+	Value string `json:"value,omitempty"`
 }
 
 func (s SoftlayerClient) New(user string, key string) *SoftlayerClient {
@@ -302,6 +310,8 @@ func (s SoftlayerClient) CreateInstance(instance InstanceType) (map[string]inter
 				MaxSpeed: instance.NetworkSpeed,
 			},
 		},
+		UserData:      instance.UserData,
+		UserDataCount: instance.UserDataCount,
 	}
 
 	if instance.ProvisioningSshKeyId != 0 {

--- a/builder/ibmcloud/classic/config.go
+++ b/builder/ibmcloud/classic/config.go
@@ -4,6 +4,7 @@ package classic
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/common"
@@ -38,6 +39,7 @@ type Config struct {
 	InstanceNetworkSpeed           int     `mapstructure:"instance_network_speed"`
 	ProvisioningSshKeyId           int64   `mapstructure:"provisioning_ssh_key_id"`
 	InstancePublicSecurityGroupIds []int64 `mapstructure:"public_security_groups"`
+	UserDataFilePath               string  `mapstructure:"user_data_file_path"`
 
 	RawStateTimeout string              `mapstructure:"instance_state_timeout"`
 	StateTimeout    time.Duration       `mapstructure-to-hcl2:",skip"`
@@ -156,6 +158,13 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			errs, fmt.Errorf("[ERROR] Failed parsing state_timeout: %s", err))
 	}
 	c.StateTimeout = stateTimeout
+
+	if c.UserDataFilePath != "" {
+		if _, err := os.ReadFile(c.UserDataFilePath); err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err))
+		}
+	}
 
 	//log.Println(common.ScrubConfig(self.config, c.APIKey, c.Username))
 

--- a/builder/ibmcloud/classic/config.hcl2spec.go
+++ b/builder/ibmcloud/classic/config.hcl2spec.go
@@ -87,6 +87,7 @@ type FlatConfig struct {
 	InstanceNetworkSpeed           *int              `mapstructure:"instance_network_speed" cty:"instance_network_speed" hcl:"instance_network_speed"`
 	ProvisioningSshKeyId           *int64            `mapstructure:"provisioning_ssh_key_id" cty:"provisioning_ssh_key_id" hcl:"provisioning_ssh_key_id"`
 	InstancePublicSecurityGroupIds []int64           `mapstructure:"public_security_groups" cty:"public_security_groups" hcl:"public_security_groups"`
+	UserDataFilePath               *string           `mapstructure:"user_data_file_path" cty:"user_data_file_path" hcl:"user_data_file_path"`
 	RawStateTimeout                *string           `mapstructure:"instance_state_timeout" cty:"instance_state_timeout" hcl:"instance_state_timeout"`
 }
 
@@ -179,6 +180,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_network_speed":       &hcldec.AttrSpec{Name: "instance_network_speed", Type: cty.Number, Required: false},
 		"provisioning_ssh_key_id":      &hcldec.AttrSpec{Name: "provisioning_ssh_key_id", Type: cty.Number, Required: false},
 		"public_security_groups":       &hcldec.AttrSpec{Name: "public_security_groups", Type: cty.List(cty.Number), Required: false},
+		"user_data_file_path":          &hcldec.AttrSpec{Name: "user_data_file_path", Type: cty.String, Required: false},
 		"instance_state_timeout":       &hcldec.AttrSpec{Name: "instance_state_timeout", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/ibmcloud/classic/step_create_instance.go
+++ b/builder/ibmcloud/classic/step_create_instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
@@ -44,6 +45,17 @@ func (s *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) mu
 		ProvisioningSshKeyId:   ProvisioningSshKeyId,
 		BaseImageId:            config.BaseImageId,
 		BaseOsCode:             config.BaseOsCode,
+	}
+
+	if config.UserDataFilePath != "" {
+		if userDataBytes, err := os.ReadFile(config.UserDataFilePath); err == nil {
+			instanceDefinition.UserData = []Attribute{{Value: string(userDataBytes)}}
+			instanceDefinition.UserDataCount += 1
+		} else {
+			ui.Error(err.Error())
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
 	}
 
 	ui.Say("Creating an instance...")


### PR DESCRIPTION
The userdata field allows the user to inject metadata into the virtual server at boot time.

Support for classic works in a similar way as VPC: by reading the file that is (optionally) passed by the user by means of the `user_data_file_path` parameter.

Fixes: #58 