### PR TITLE
Create security groups with given resource group

### DIFF
--- a/builder/ibmcloud/vpc/step_create_sec_group_rules.go
+++ b/builder/ibmcloud/vpc/step_create_sec_group_rules.go
@@ -27,6 +27,12 @@ func (s *stepCreateSecurityGroupRules) Run(_ context.Context, state multistep.St
 		})
 		options.SetName(config.SecurityGroupName)
 
+		if config.ResourceGroupID != "" {
+			options.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
+				ID: &config.ResourceGroupID,
+			}
+		}
+
 		SecurityGroupData, err := client.createSecurityGroup(state, *options)
 		if err != nil {
 			err := fmt.Errorf("[ERROR] Error creating a Temp Security Group: %s", err)


### PR DESCRIPTION
...much as we do elsewhere, if the configuration specifies a resource group, honor it and use it to create security group.

Note that the lack of this is causing issues when blanket permissions are not granted to the default resource group, e.g.

```
2023-01-04T20:40:53Z: ==> ibmcloud-vpc.base: [ERROR] Error creating the Security Group. Error: user does not have permission to use default resource group
2023-01-04T20:40:53Z: ==> ibmcloud-vpc.base: [ERROR] Error creating a Temp Security Group: [ERROR] Error creating the Security Group. Error: user does not have permission to use default resource group
```