### PR TITLE
Create security groups with given resource group

### DIFF
--- a/builder/ibmcloud/vpc/step_create_sec_group_rules.go
+++ b/builder/ibmcloud/vpc/step_create_sec_group_rules.go
@@ -27,6 +27,12 @@ func (s *stepCreateSecurityGroupRules) Run(_ context.Context, state multistep.St
 		})
 		options.SetName(config.SecurityGroupName)
 
+		if config.ResourceGroupID != "" {
+			options.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
+				ID: &config.ResourceGroupID,
+			}
+		}
+
 		SecurityGroupData, err := client.createSecurityGroup(state, *options)
 		if err != nil {
 			err := fmt.Errorf("[ERROR] Error creating a Temp Security Group: %s", err)


### PR DESCRIPTION
...much as we do elsewhere, if the configuration specifies a resource group, honor it and use it to create security group.

(This is the twin of #64)

Signed-off-by: Chris Weyl <cweyl@ibm.com>