### PR TITLE
fix: use vsiBaseImageID if present

### DIFF
--- a/builder/ibmcloud/vpc/step_create_instance.go
+++ b/builder/ibmcloud/vpc/step_create_instance.go
@@ -144,30 +144,33 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
 		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
 
-	} else if vsiBaseImageName != "" {
-		// Get Image ID
+	} else if vsiBaseImageName != "" || vsiBaseImageID != "" {
 
-		ui.Say("Fetching ImageID...")
-
-		options := &vpcv1.ListImagesOptions{}
-		options.SetName(vsiBaseImageName)
-		image, _, err := vpcService.ListImages(options)
-
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error getting image with name: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
+		if vsiBaseImageID != "" {
+			// Get Image ID
+	
+			ui.Say("Fetching ImageID...")
+	
+			options := &vpcv1.ListImagesOptions{}
+			options.SetName(vsiBaseImageName)
+			image, _, err := vpcService.ListImages(options)
+	
+			if err != nil {
+				err := fmt.Errorf("[ERROR] Error getting image with name: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
+			if image != nil && len(image.Images) == 0 {
+				err := fmt.Errorf("[ERROR] Image %s not found", vsiBaseImageName)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
+			vsiBaseImageID = *image.Images[0].ID
+			ui.Say(fmt.Sprintf("ImageID fetched: %s", string(vsiBaseImageName)))
 		}
-		if image != nil && len(image.Images) == 0 {
-			err := fmt.Errorf("[ERROR] Image %s not found", vsiBaseImageName)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		vsiBaseImageID = *image.Images[0].ID
-		ui.Say(fmt.Sprintf("ImageID fetched: %s", string(vsiBaseImageName)))
-
+		
 		imageIdentityModel := &vpcv1.ImageIdentityByID{
 			ID: &[]string{vsiBaseImageID}[0],
 		}


### PR DESCRIPTION
This Packer plugin will crash when a build is started that references an image ID instead of an image name. I modified the existing block that checks for the presence of vsiBaseImageName, and added an extra condition to check for vsiBaseImageID not empty.

Inside that condition, I wrapped the ID fetch routine inside a condition that will only execute if vsiBaseImageID is empty.