### PR TITLE
fix: use vsiBaseImageID if present

### DIFF
--- a/builder/ibmcloud/vpc/step_create_instance.go
+++ b/builder/ibmcloud/vpc/step_create_instance.go
@@ -144,29 +144,32 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
 		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
 
-	} else if vsiBaseImageName != "" {
-		// Get Image ID
+	} else if vsiBaseImageName != "" || vsiBaseImageID != "" {
 
-		ui.Say("Fetching ImageID...")
+                if vsiBaseImageID == "" {
+			// Get Image ID
 
-		options := &vpcv1.ListImagesOptions{}
-		options.SetName(vsiBaseImageName)
-		image, _, err := vpcService.ListImages(options)
+                        ui.Say("Fetching ImageID...")
 
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error getting image with name: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		if image != nil && len(image.Images) == 0 {
-			err := fmt.Errorf("[ERROR] Image %s not found", vsiBaseImageName)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		vsiBaseImageID = *image.Images[0].ID
-		ui.Say(fmt.Sprintf("ImageID fetched: %s", string(vsiBaseImageName)))
+                        options := &vpcv1.ListImagesOptions{}
+                        options.SetName(vsiBaseImageName)
+                        image, _, err := vpcService.ListImages(options)
+
+                        if err != nil {
+                                err := fmt.Errorf("[ERROR] Error getting image with name: %s", err)
+                                state.Put("error", err)
+                                ui.Error(err.Error())
+                                return multistep.ActionHalt
+                        }
+                        if image != nil && len(image.Images) == 0 {
+                                err := fmt.Errorf("[ERROR] Image %s not found", vsiBaseImageName)
+                                state.Put("error", err)
+                                ui.Error(err.Error())
+                                return multistep.ActionHalt
+                        }
+                        vsiBaseImageID = *image.Images[0].ID
+                        ui.Say(fmt.Sprintf("ImageID fetched: %s", string(vsiBaseImageName)))
+                }
 
 		imageIdentityModel := &vpcv1.ImageIdentityByID{
 			ID: &[]string{vsiBaseImageID}[0],


### PR DESCRIPTION
Current code path ignores vsiBaseImageID, leading to a crash if used on its own. I've modified the condition that handles vsiBaseImageName, to also check for and prefer vsiBaseImageID if present.

This should close #108.