### PR TITLE
Normalize disk image names to exclude new metadata disks in Classic VSI

### DIFF
--- a/builder/ibmcloud/classic/client.go
+++ b/builder/ibmcloud/classic/client.go
@@ -480,10 +480,10 @@ func (s SoftlayerClient) findNonSwapBlockDeviceIds(blockDevices []interface{}) [
 	for _, val := range blockDevices {
 		blockDevice := val.(map[string]interface{})
 		diskImage := blockDevice["diskImage"].(map[string]interface{})
-		name := diskImage["name"].(string)
+		name := strings.ToUpper(strings.TrimSpace(diskImage["name"].(string)))
 		id := int64(blockDevice["id"].(float64))
 
-		if !strings.Contains(name, "SWAP") && !strings.Contains(name, "METADATA") {
+                if !strings.HasSuffix(name, "SWAP") && !strings.HasSuffix(name, "METADATA") {
 			blockDeviceIds[deviceCount] = id
 			deviceCount++
 		}


### PR DESCRIPTION
### **Context**

IBM Cloud Classic VSI metadata disk names have changed in newer instances. This caused Packer builds to **accidentally include metadata disks** during image capture, leading to SoftLayer API errors like:

```
Invalid block device supplied. Please be sure to not include any metadata disk block devices.
```

---

### ✅ **What Changed**

Previously, metadata disks had names like:

```
$HOSTNAME-<ID>-METADATA
```

These matched the existing filtering logic, which looked for disk names containing `"METADATA"`.

In newer Classic VSI instances, the disk name format has changed to:

```
$HOSTNAME - Metadata
```

To support both formats, this update **normalizes the disk image name** by trimming whitespace and converting it to uppercase:

```go
name := strings.ToUpper(strings.TrimSpace(diskImage["name"].(string)))
```

This makes the comparison case- and format-insensitive, allowing us to reliably detect and exclude metadata disks regardless of naming differences.

---

### 🧪 **Testing**

* Tested on newer Classic VSI builds where the updated metadata disk name was observed.
* Not yet fully regression tested across older VSIs.
* Image capture now succeeds where it previously failed.

---

### 📌 **Result**

This change prevents the inclusion of metadata disks in the image capture process and resolves the following API error:

```
Invalid block device supplied. Please be sure to not include any metadata disk block devices.
```


