### PR TITLE
fix: add missing 404 check for floating IP cleanup in step_create_instance

### DIFF
--- a/builder/ibmcloud/vpc/step_create_instance.go
+++ b/builder/ibmcloud/vpc/step_create_instance.go
@@ -377,8 +377,8 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 			floatingIPID := state.Get("floating_ip_id").(string)
 
 			options := vpcService.NewGetFloatingIPOptions(floatingIPID)
-			floatingIPresponse, _, err := vpcService.GetFloatingIP(options)
-			if err != nil {
+			floatingIPresponse, response, err := vpcService.GetFloatingIP(options)
+			if err != nil && response.StatusCode != 404 {
 				err := fmt.Errorf("[ERROR] Error getting the Floating IP: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())


### PR DESCRIPTION
Fixes duplicate floating IP deletion error when using multiple provisioners. Both step_create_instance and step_waitfor_instance attempt to clean up the same floating IP, but only step_waitfor_instance had the 404 status check.

Fixes #133

🤖 Generated with [Claude Code](https://claude.ai/code)