### PR TITLE
Widen vsi_boot_vol_capacity bounds to 10–32000 GB (align with IBM VPC minimum and sdp profile)

### DIFF
--- a/builder/ibmcloud/vpc/config.go
+++ b/builder/ibmcloud/vpc/config.go
@@ -113,8 +113,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, errors.New("a subnet_id must be specified"))
 	}
 
-	if c.VSIBootCapacity != 0 && (c.VSIBootCapacity < 100 || c.VSIBootCapacity > 250) {
-		errs = packer.MultiErrorAppend(errs, errors.New("boot capacity out of bound: provide a valid capacity between 100 to 250"))
+	if c.VSIBootCapacity != 0 && (c.VSIBootCapacity < 10 || c.VSIBootCapacity > 250) {
+		errs = packer.MultiErrorAppend(errs, errors.New("boot capacity out of bound: provide a valid capacity between 10 and 250"))
 	}
 	if c.VSIBootProfile != "" && (c.VSIBootProfile != "5iops-tier" && c.VSIBootProfile != "10iops-tier" && c.VSIBootProfile != "general-purpose") {
 		errs = packer.MultiErrorAppend(errs, errors.New("profile must be from:  5iops-tier, 10iops-tier, general-purpose"))

--- a/builder/ibmcloud/vpc/config.go
+++ b/builder/ibmcloud/vpc/config.go
@@ -113,8 +113,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, errors.New("a subnet_id must be specified"))
 	}
 
-	if c.VSIBootCapacity != 0 && (c.VSIBootCapacity < 10 || c.VSIBootCapacity > 250) {
-		errs = packer.MultiErrorAppend(errs, errors.New("boot capacity out of bound: provide a valid capacity between 10 and 250"))
+	if c.VSIBootCapacity != 0 && (c.VSIBootCapacity < 10 || c.VSIBootCapacity > 32000) {
+		errs = packer.MultiErrorAppend(errs, errors.New("boot capacity out of bound: provide a valid capacity between 10 and 32000"))
 	}
 	if c.VSIBootProfile != "" && (c.VSIBootProfile != "5iops-tier" && c.VSIBootProfile != "10iops-tier" && c.VSIBootProfile != "general-purpose") {
 		errs = packer.MultiErrorAppend(errs, errors.New("profile must be from:  5iops-tier, 10iops-tier, general-purpose"))

--- a/builder/ibmcloud/vpc/config_test.go
+++ b/builder/ibmcloud/vpc/config_test.go
@@ -1,0 +1,50 @@
+package vpc
+
+import (
+	"strings"
+	"testing"
+)
+
+// otherwise-valid config so Prepare surfaces only the boot-capacity check.
+func validBootCapacityConfig() *Config {
+	c := &Config{}
+	c.Comm.Type = "ssh"
+	c.IBMApiKey = "test-api-key"
+	c.Region = "us-east"
+	c.SubnetID = "0717-test-subnet"
+	c.VSIBaseImageID = "r014-test-image"
+	c.VSIProfile = "bz2-4x16"
+	return c
+}
+
+func TestPrepareBootVolumeCapacity(t *testing.T) {
+	const wantMsg = "boot capacity out of bound"
+
+	cases := []struct {
+		name       string
+		capacity   int
+		wantReject bool
+	}{
+		{"zero uses image default", 0, false},
+		{"minimum 10", 10, false},
+		{"just below minimum", 9, true},
+		{"mid range", 50, false},
+		{"maximum 250", 250, false},
+		{"just above maximum", 251, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validBootCapacityConfig()
+			c.VSIBootCapacity = tc.capacity
+
+			_, err := c.Prepare()
+
+			rejected := err != nil && strings.Contains(err.Error(), wantMsg)
+			if rejected != tc.wantReject {
+				t.Errorf("VSIBootCapacity=%d: boot-capacity rejected=%v, want %v (err=%v)",
+					tc.capacity, rejected, tc.wantReject, err)
+			}
+		})
+	}
+}

--- a/builder/ibmcloud/vpc/config_test.go
+++ b/builder/ibmcloud/vpc/config_test.go
@@ -29,8 +29,9 @@ func TestPrepareBootVolumeCapacity(t *testing.T) {
 		{"minimum 10", 10, false},
 		{"just below minimum", 9, true},
 		{"mid range", 50, false},
-		{"maximum 250", 250, false},
-		{"just above maximum", 251, true},
+		{"sdp range above old limit", 1000, false},
+		{"maximum 32000", 32000, false},
+		{"just above maximum", 32001, true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What

Widen the accepted range for `vsi_boot_vol_capacity` in the VPC builder from **100–250 GB to 10–32000 GB** (`0` still means "use the image default"). A small change to the validation in `builder/ibmcloud/vpc/config.go`, plus a unit test.

- **Minimum lowered 100 → 10 GB.**
- **Maximum raised 250 → 32000 GB** (the `sdp` profile ceiling), per reviewer feedback.

## Why

**Minimum (100 → 10):** IBM Cloud VPC boot volumes are valid well below 100 GB — the real minimum is the source image's `minimum_provisioned_size`, which for the stock minimal images (e.g. `ibm-ubuntu-24-04-*-minimal-s390x-*`) is **10 GB**. The old `< 100` check rejected every capacity between 10 and 99 GB even though IBM Cloud accepts them. It also contradicts the plugin's own docs, which describe the field as "Must be at least the image's `minimum_provisioned_size`."

**Maximum (250 → 32000):** IBM Cloud no longer enforces a fixed 250 GB ceiling, and the `sdp` profile supports volumes up to 32000 GB (raised in review at the request of @astha-jain and @deepakibms). The old `> 250` check rejected valid larger volumes.

**This stays safe** because the precise per-profile limits are still enforced server-side: IBM Cloud rejects a capacity below the chosen image's `minimum_provisioned_size`, or above the profile's maximum, with a clear API error. The `10` and `32000` here are just IBM VPC's documented absolute floor and ceiling — a static client-side sanity guard — so widening the range doesn't admit genuinely-invalid values, it only stops the plugin from pre-rejecting valid ones.

### Impact
Lets users right-size the builder boot volume (and therefore the captured image) across the full range IBM supports, instead of being boxed into 100–250 GB. Purely a relaxation: `0` and any value already in 100–250 behave exactly as before.

## Testing
- Unit test `TestPrepareBootVolumeCapacity` covers the bound: `0` / `10` / `50` / `1000` / `32000` accepted, `9` / `32001` rejected.
- `go test ./builder/ibmcloud/vpc/...` and `go vet ./builder/ibmcloud/vpc/...` pass.

Commits are DCO signed-off per CONTRIBUTING.md.
