### PR TITLE
fix(vpc): fail the build when CRN verification fails

### DIFF
--- a/builder/ibmcloud/vpc/step_verify_input.go
+++ b/builder/ibmcloud/vpc/step_verify_input.go
@@ -222,60 +222,14 @@ func (s *stepVerifyInput) Run(_ context.Context, state multistep.StateBag) multi
 			Authenticator: vpcService.Service.Options.Authenticator,
 		}
 		globalSearchAPIV2, err := searchv2.NewGlobalSearchV2(globalSearchV2Options)
-
 		if err != nil {
-			fmt.Println("GlobalSearch Service creation failed.", err)
+			err = fmt.Errorf("[ERROR] Global Search service creation failed: %w", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
 		}
-		// validate catalog offering crn
-		if config.CatalogOfferingCRN != "" {
-			crnToCheck := fmt.Sprintf("%s%s", strings.Split(config.CatalogOfferingCRN, ":offering")[0], "::")
-			query := fmt.Sprintf("crn:\"%s\"", crnToCheck)
-			searchOptions := &searchv2.SearchOptions{
-				Query: &query,
-			}
-			res, _, _ := globalSearchAPIV2.Search(searchOptions)
-			if len(res.Items) != 0 {
-				ui.Say(fmt.Sprintf("%s Catalog information successfully retrieved ...", res.Items[0].GetProperty("name")))
-			} else {
-				err := fmt.Errorf("[ERROR] Catalog crn (%s) information could not be retrieved", config.CatalogOfferingCRN)
-				state.Put("Catalog offering crn information could not be retrieved", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-		}
-		// validate catalog version crn
-		if config.CatalogOfferingVersionCRN != "" {
-			crnToCheck := fmt.Sprintf("%s%s", strings.Split(config.CatalogOfferingVersionCRN, ":version")[0], "::")
-			query := fmt.Sprintf("crn:\"%s\"", crnToCheck)
-			searchOptions := &searchv2.SearchOptions{
-				Query: &query,
-			}
-			res, _, _ := globalSearchAPIV2.Search(searchOptions)
-			if len(res.Items) != 0 {
-				ui.Say(fmt.Sprintf("%s Catalog information successfully retrieved ...", res.Items[0].GetProperty("name")))
-			} else {
-				err := fmt.Errorf("[ERROR] Catalog version crn (%s) information could not be retrieved", config.CatalogOfferingVersionCRN)
-				state.Put("Catalog version crn information could not be retrieved", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-		}
-		// validate encryption key crn
-		if config.EncryptionKeyCRN != "" {
-			crnToCheck := fmt.Sprintf("%s%s", strings.Split(config.EncryptionKeyCRN, ":key")[0], "::")
-			query := fmt.Sprintf("crn:\"%s\"", crnToCheck)
-			searchOptions := &searchv2.SearchOptions{
-				Query: &query,
-			}
-			res, _, _ := globalSearchAPIV2.Search(searchOptions)
-			if len(res.Items) != 0 {
-				ui.Say(fmt.Sprintf("%s Encryption information successfully retrieved ...", res.Items[0].GetProperty("name")))
-			} else {
-				err := fmt.Errorf("[ERROR] Encryption crn (%s) information could not be retrieved", config.EncryptionKeyCRN)
-				state.Put("Encryption information could not be retrieved", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
+		if action := verifyCRNs(globalSearchAPIV2, config, ui, state); action != multistep.ActionContinue {
+			return action
 		}
 	}
 	return multistep.ActionContinue
@@ -283,4 +237,73 @@ func (s *stepVerifyInput) Run(_ context.Context, state multistep.StateBag) multi
 
 func (s *stepVerifyInput) Cleanup(state multistep.StateBag) {
 
+}
+
+// crnSearcher is the subset of *globalsearchv2.GlobalSearchV2 used to validate
+// CRNs. It is declared as an interface so verifyCRNs can be exercised with a
+// fake searcher in unit tests.
+type crnSearcher interface {
+	Search(searchOptions *searchv2.SearchOptions) (result *searchv2.ScanResult, response *core.DetailedResponse, err error)
+}
+
+// Compile-time guarantee that the production client satisfies crnSearcher, so an
+// SDK signature change fails here rather than at the call site in Run.
+var _ crnSearcher = (*searchv2.GlobalSearchV2)(nil)
+
+// verifyCRNs confirms each configured CRN (catalog offering, catalog version,
+// encryption key) resolves via Global Search. Any verification failure records
+// the error under the "error" state key — which is how Packer core detects a
+// failed build — and halts. Without that key the build would stop with no
+// artifact yet exit 0 (a silent failure).
+func verifyCRNs(search crnSearcher, config Config, ui packer.Ui, state multistep.StateBag) multistep.StepAction {
+	checks := []struct {
+		crn       string
+		separator string
+		// noun is the resource word in the success message ("Catalog",
+		// "Encryption"); label is the longer phrase in the not-found message
+		// ("Catalog crn", "Catalog version crn", "Encryption crn").
+		noun  string
+		label string
+	}{
+		{config.CatalogOfferingCRN, ":offering", "Catalog", "Catalog crn"},
+		{config.CatalogOfferingVersionCRN, ":version", "Catalog", "Catalog version crn"},
+		{config.EncryptionKeyCRN, ":key", "Encryption", "Encryption crn"},
+	}
+	for _, c := range checks {
+		if c.crn == "" {
+			continue
+		}
+		if action := verifyCRN(search, c.crn, c.separator, c.noun, c.label, ui, state); action != multistep.ActionContinue {
+			return action
+		}
+	}
+	return multistep.ActionContinue
+}
+
+// verifyCRN looks up a single CRN via Global Search. A Search transport/auth
+// error, a nil result, or a result with no items are all treated as a failed
+// verification: the error is stored under "error" and the step halts. A Search
+// error must not be discarded — doing so previously turned an auth/network
+// failure into either a nil-pointer panic or a misreported "not found".
+func verifyCRN(search crnSearcher, crn, separator, noun, label string, ui packer.Ui, state multistep.StateBag) multistep.StepAction {
+	crnToCheck := fmt.Sprintf("%s%s", strings.Split(crn, separator)[0], "::")
+	query := fmt.Sprintf("crn:\"%s\"", crnToCheck)
+	searchOptions := &searchv2.SearchOptions{
+		Query: &query,
+	}
+	res, _, err := search.Search(searchOptions)
+	if err != nil {
+		err = fmt.Errorf("[ERROR] %s (%s) could not be verified via Global Search: %w", label, crn, err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	if res == nil || len(res.Items) == 0 {
+		err := fmt.Errorf("[ERROR] %s (%s) information could not be retrieved", label, crn)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	ui.Say(fmt.Sprintf("%s %s information successfully retrieved ...", res.Items[0].GetProperty("name"), noun))
+	return multistep.ActionContinue
 }

--- a/builder/ibmcloud/vpc/step_verify_input_test.go
+++ b/builder/ibmcloud/vpc/step_verify_input_test.go
@@ -1,0 +1,207 @@
+package vpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	searchv2 "github.com/IBM/platform-services-go-sdk/globalsearchv2"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// fakeSearcher stands in for *globalsearchv2.GlobalSearchV2.
+//
+//   - err != nil      => every Search returns (nil, nil, err), modelling a
+//     transport/auth failure (the real SDK leaves result nil on error).
+//   - results != nil  => each call returns the next entry in order, modelling
+//     several CRN lookups where a later one differs from earlier ones.
+//   - otherwise       => every call returns result.
+//
+// Every query string seen is recorded in queries, so a test can assert the
+// lookup query verifyCRN builds from the CRN.
+type fakeSearcher struct {
+	result  *searchv2.ScanResult
+	results []*searchv2.ScanResult
+	err     error
+	calls   int
+	queries []string
+}
+
+func (f *fakeSearcher) Search(opts *searchv2.SearchOptions) (*searchv2.ScanResult, *core.DetailedResponse, error) {
+	if opts != nil && opts.Query != nil {
+		f.queries = append(f.queries, *opts.Query)
+	}
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	if f.results != nil {
+		r := f.results[f.calls]
+		f.calls++
+		return r, nil, nil
+	}
+	return f.result, nil, nil
+}
+
+// resolved is a non-nil result carrying one item — a CRN that exists.
+func resolved() *searchv2.ScanResult {
+	item := searchv2.ResultItem{}
+	item.SetProperty("name", "test-resource")
+	return &searchv2.ScanResult{Items: []searchv2.ResultItem{item}}
+}
+
+// notFound is the real API's "not found" shape: a non-nil result with no items.
+func notFound() *searchv2.ScanResult {
+	return &searchv2.ScanResult{}
+}
+
+// assertErrorFails checks the build was made to fail: the step halted and the
+// "error" state key holds a non-nil error (Packer core reads that key — a
+// present-but-nil or non-error value would not fail the build).
+func assertErrorFails(t *testing.T, action multistep.StepAction, state *multistep.BasicStateBag) {
+	t.Helper()
+	if action != multistep.ActionHalt {
+		t.Fatalf("expected ActionHalt, got %v", action)
+	}
+	v, ok := state.GetOk("error")
+	if !ok {
+		t.Fatal(`verification failure must set the "error" state key so Packer core fails the build`)
+	}
+	if err, isErr := v.(error); !isErr || err == nil {
+		t.Fatalf(`"error" state key must hold a non-nil error, got %T (%v)`, v, v)
+	}
+}
+
+// An unresolved CRN must fail the build, not pass silently. The regression: the
+// failure has to land under the "error" state key (Packer core reads that key to
+// decide the build failed), and the step must halt.
+func TestVerifyCRNs_UnresolvedCRNFailsBuild(t *testing.T) {
+	cases := map[string]Config{
+		"catalog offering": {CatalogOfferingCRN: "crn:v1:bluemix:public:globalcatalog::::offering:x"},
+		"catalog version":  {CatalogOfferingVersionCRN: "crn:v1:bluemix:public:globalcatalog::::version:x"},
+		"encryption key":   {EncryptionKeyCRN: "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:x"},
+	}
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			state := new(multistep.BasicStateBag)
+
+			action := verifyCRNs(&fakeSearcher{result: notFound()}, config, packer.TestUi(t), state)
+
+			assertErrorFails(t, action, state)
+		})
+	}
+}
+
+// A Global Search transport/auth error must fail the build cleanly — not panic
+// (the SDK returns a nil result on error) and not be misreported as "not found".
+func TestVerifyCRNs_SearchErrorFailsBuild(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	config := Config{EncryptionKeyCRN: "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:x"}
+
+	action := verifyCRNs(&fakeSearcher{err: errors.New("403 Forbidden")}, config, packer.TestUi(t), state)
+
+	assertErrorFails(t, action, state)
+}
+
+// Defensive: a nil result with no error must be treated as a failure, not
+// dereferenced.
+func TestVerifyCRNs_NilResultFailsBuild(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	config := Config{EncryptionKeyCRN: "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:x"}
+
+	action := verifyCRNs(&fakeSearcher{result: nil}, config, packer.TestUi(t), state)
+
+	assertErrorFails(t, action, state)
+}
+
+func TestVerifyCRNs_ResolvedCRNContinues(t *testing.T) {
+	cases := map[string]Config{
+		"catalog offering": {CatalogOfferingCRN: "crn:v1:bluemix:public:globalcatalog::::offering:x"},
+		"catalog version":  {CatalogOfferingVersionCRN: "crn:v1:bluemix:public:globalcatalog::::version:x"},
+		"encryption key":   {EncryptionKeyCRN: "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:x"},
+	}
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			state := new(multistep.BasicStateBag)
+
+			action := verifyCRNs(&fakeSearcher{result: resolved()}, config, packer.TestUi(t), state)
+
+			if action != multistep.ActionContinue {
+				t.Fatalf("expected ActionContinue for a resolved CRN, got %v", action)
+			}
+			if _, ok := state.GetOk("error"); ok {
+				t.Fatal("a resolved CRN must not set the error state key")
+			}
+		})
+	}
+}
+
+// The lookup query is the CRN truncated at its type segment (":offering",
+// ":version", ":key") with "::" appended — so each CRN kind must use its own
+// separator and produce the expected prefix query.
+func TestVerifyCRNs_BuildsPrefixQuery(t *testing.T) {
+	cases := []struct {
+		name      string
+		config    Config
+		wantQuery string
+	}{
+		{
+			"catalog offering",
+			Config{CatalogOfferingCRN: "crn:v1:bluemix:public:globalcatalog:global:a/acct:cat-id:offering:off-id"},
+			`crn:"crn:v1:bluemix:public:globalcatalog:global:a/acct:cat-id::"`,
+		},
+		{
+			"catalog version",
+			Config{CatalogOfferingVersionCRN: "crn:v1:bluemix:public:globalcatalog:global:a/acct:cat-id:version:ver-id"},
+			`crn:"crn:v1:bluemix:public:globalcatalog:global:a/acct:cat-id::"`,
+		},
+		{
+			"encryption key",
+			Config{EncryptionKeyCRN: "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:key-id"},
+			`crn:"crn:v1:bluemix:public:kms:us-east:a/acct:inst::"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			search := &fakeSearcher{result: resolved()}
+
+			verifyCRNs(search, tc.config, packer.TestUi(t), new(multistep.BasicStateBag))
+
+			if len(search.queries) != 1 {
+				t.Fatalf("expected exactly 1 Search query, got %d: %v", len(search.queries), search.queries)
+			}
+			if search.queries[0] != tc.wantQuery {
+				t.Errorf("query mismatch:\n got: %s\nwant: %s", search.queries[0], tc.wantQuery)
+			}
+		})
+	}
+}
+
+// With all three CRNs set, an unresolved one checked last must still halt and
+// set "error" — i.e. earlier successes don't short-circuit the later checks.
+func TestVerifyCRNs_LaterCRNFailureHalts(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	config := Config{
+		CatalogOfferingCRN:        "crn:v1:bluemix:public:globalcatalog::::offering:x",
+		CatalogOfferingVersionCRN: "crn:v1:bluemix:public:globalcatalog::::version:x",
+		EncryptionKeyCRN:          "crn:v1:bluemix:public:kms:us-east:a/acct:inst:key:x",
+	}
+	search := &fakeSearcher{results: []*searchv2.ScanResult{resolved(), resolved(), notFound()}}
+
+	action := verifyCRNs(search, config, packer.TestUi(t), state)
+
+	assertErrorFails(t, action, state)
+	if search.calls != 3 {
+		t.Fatalf("expected all 3 CRNs checked in order, got %d Search calls", search.calls)
+	}
+}
+
+func TestVerifyCRNs_NoCRNConfigured(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+
+	action := verifyCRNs(&fakeSearcher{}, Config{}, packer.TestUi(t), state)
+
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue when no CRN is configured, got %v", action)
+	}
+}


### PR DESCRIPTION
## Summary

`stepVerifyInput` validates the catalog-offering, catalog-version, and encryption-key CRNs against IBM Cloud Global Search before the build proceeds. Several of its failure paths did not actually fail the Packer build — most seriously, an unverifiable **encryption key** would let the build "succeed" while producing no image.

## The bug

1. **Silent success on "not found".** The three not-found branches stored their error under a human-readable state-bag key (e.g. `state.Put("Encryption information could not be retrieved", err)`) and returned `multistep.ActionHalt`. Packer core decides whether a build failed by reading `state["error"]` (see `builder.go`), so these keys were never read: the step halted, no image was captured, yet `packer build` exited **0** and printed only *"Builds finished but no artifacts were created."* Every other error path in this file already uses the `"error"` key — these three were the outliers.

2. **Discarded Search error + nil-pointer panic.** Each lookup did `res, _, _ := search.Search(...)` and then dereferenced `res.Items`. On a transport/auth error (401/403/429/5xx, network drop) the SDK returns a **nil** `*ScanResult`, so the step either panicked on the nil dereference or — when an empty result came back — misreported an infrastructure failure as "CRN not found."

3. **Construction error ignored.** A `NewGlobalSearchV2` failure was only `fmt.Println`'d (bypassing the Packer UI) and execution continued with a nil client.

## The fix

- Store every verification failure under `state.Put("error", err)` and halt, so the build fails with a non-zero exit.
- Capture the `Search` error and surface it **distinctly** from "not found", and guard against a nil result.
- Halt (and record `"error"`) when `NewGlobalSearchV2` fails, instead of printing and continuing.
- Collapse the three near-identical CRN blocks into one table-driven `verifyCRN` helper behind a small consumer-side `crnSearcher` interface (the single `Search` method), with a compile-time `var _ crnSearcher = (*GlobalSearchV2)(nil)` assertion so an SDK signature change fails at the interface rather than the call site.

User-facing log messages are unchanged for the existing not-found and success paths.

## Why it's safe

- **Behavior-preserving on the happy path.** A resolved CRN still emits the same "… information successfully retrieved …" message and continues; the not-found messages are byte-identical. The only behavioral change is that genuine failures now stop the build (the intended Packer contract) rather than passing silently.
- **No new dependencies.** The `crnSearcher` interface mirrors the existing `*globalsearchv2.GlobalSearchV2.Search` signature exactly, so the production client satisfies it with no adapter or wrapper.
- **Tested.** The `builder/` package previously had no unit tests; this adds focused coverage:
  - unresolved CRN halts and sets `"error"` (all three CRN kinds)
  - a `Search` error fails the build (no panic, no misreport)
  - a nil result fails the build
  - a resolved CRN continues without error (all three kinds)
  - a later-of-multiple CRN failure still halts
  - no configured CRN continues

  `go build ./...`, `go vet`, and `go test ./builder/ibmcloud/vpc/` all pass; `gofmt` clean.

## How it surfaced

A KMS-encrypted image bake reported success but produced no image when the build identity lacked read access to the encryption key: the encryption-CRN pre-flight failed, halted the step, and exited 0. This change turns that — and the related Search-failure paths — into a hard build failure.
