### PR TITLE
fix(vpc): fail the build when image capture fails

### DIFF
--- a/builder/ibmcloud/vpc/builder.go
+++ b/builder/ibmcloud/vpc/builder.go
@@ -2,7 +2,7 @@ package vpc
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -12,6 +12,27 @@ import (
 )
 
 const BuilderId = "ibmcloud.vpc.builder"
+
+// buildResultError inspects the state bag after the step runner finishes
+// (whether it ran to completion or a step halted) and returns a non-nil error
+// when the build did not successfully produce an image.
+//
+// By convention a failing step records its error under the "error" key; this
+// function reads it so Run can return it. (Packer core decides a build failed
+// from the error returned by Builder.Run, not from the state bag directly.) A
+// step may also halt without recording an explicit error; in that case the
+// absence of "image_id" still means the build did not complete, so it must be
+// reported as a failure rather than letting Run return (nil, nil) — which Packer
+// treats as success, exiting 0 with no artifact.
+func buildResultError(state multistep.StateBag) error {
+	if err, ok := state.GetOk("error"); ok {
+		return err.(error)
+	}
+	if _, ok := state.GetOk("image_id"); !ok {
+		return fmt.Errorf("[ERROR] build halted before an image was created (no image_id in state)")
+	}
+	return nil
+}
 
 // Builder represents a Packer Builder.
 type Builder struct {
@@ -107,14 +128,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	b.runner = &multistep.BasicRunner{Steps: steps}
 	b.runner.Run(ctx, state)
 
-	// If there was an error, return that
-	if err, ok := state.GetOk("error"); ok {
-		return nil, err.(error)
-	}
-
-	if _, ok := state.GetOk("image_id"); !ok {
-		log.Println("Failed to find image_id in state.")
-		return nil, nil
+	// Fail the build if a step recorded an error, or if it halted before an image
+	// was produced (see buildResultError). Returning (nil, nil) here would make
+	// Packer treat a failed build as a success and exit 0 with no artifact.
+	if err := buildResultError(state); err != nil {
+		return nil, err
 	}
 
 	// Create an artifact and return it

--- a/builder/ibmcloud/vpc/builder.go
+++ b/builder/ibmcloud/vpc/builder.go
@@ -25,8 +25,14 @@ const BuilderId = "ibmcloud.vpc.builder"
 // reported as a failure rather than letting Run return (nil, nil) — which Packer
 // treats as success, exiting 0 with no artifact.
 func buildResultError(state multistep.StateBag) error {
-	if err, ok := state.GetOk("error"); ok {
-		return err.(error)
+	// GetOk reports key presence, not a non-nil value, and a step could in
+	// principle store a non-error under "error". Only return it when it is a
+	// non-nil error; otherwise fall through to the image_id check so a malformed
+	// "error" entry can't panic or silently let the build pass.
+	if raw, ok := state.GetOk("error"); ok {
+		if err, isErr := raw.(error); isErr && err != nil {
+			return err
+		}
 	}
 	if _, ok := state.GetOk("image_id"); !ok {
 		return fmt.Errorf("[ERROR] build halted before an image was created (no image_id in state)")
@@ -128,9 +134,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	b.runner = &multistep.BasicRunner{Steps: steps}
 	b.runner.Run(ctx, state)
 
-	// Fail the build if a step recorded an error, or if it halted before an image
-	// was produced (see buildResultError). Returning (nil, nil) here would make
-	// Packer treat a failed build as a success and exit 0 with no artifact.
+	// Fail the build if a step recorded an error or halted before producing an
+	// image (see buildResultError for why returning (nil, nil) here is wrong).
 	if err := buildResultError(state); err != nil {
 		return nil, err
 	}

--- a/builder/ibmcloud/vpc/builder_test.go
+++ b/builder/ibmcloud/vpc/builder_test.go
@@ -1,0 +1,42 @@
+package vpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+func TestBuildResultError(t *testing.T) {
+	t.Run("recorded error is returned", func(t *testing.T) {
+		state := new(multistep.BasicStateBag)
+		want := errors.New("create image failed")
+		state.Put("error", want)
+		// An image_id may or may not be present; a recorded error always wins.
+		state.Put("image_id", "r006-deadbeef")
+
+		if got := buildResultError(state); got != want {
+			t.Fatalf("expected recorded error to be returned, got %v", got)
+		}
+	})
+
+	t.Run("halt with no image and no recorded error is a failure", func(t *testing.T) {
+		// This is the regression: a step halted (e.g. CreateImage failed) without
+		// recording an "error", so no image_id exists. The build must still fail
+		// rather than reporting a false success with no artifact.
+		state := new(multistep.BasicStateBag)
+
+		if err := buildResultError(state); err == nil {
+			t.Fatal("expected an error when no image_id was produced, got nil")
+		}
+	})
+
+	t.Run("image produced and no error succeeds", func(t *testing.T) {
+		state := new(multistep.BasicStateBag)
+		state.Put("image_id", "r006-deadbeef")
+
+		if err := buildResultError(state); err != nil {
+			t.Fatalf("expected success when image_id is present, got %v", err)
+		}
+	})
+}

--- a/builder/ibmcloud/vpc/builder_test.go
+++ b/builder/ibmcloud/vpc/builder_test.go
@@ -39,4 +39,17 @@ func TestBuildResultError(t *testing.T) {
 			t.Fatalf("expected success when image_id is present, got %v", err)
 		}
 	})
+
+	t.Run("nil error under the error key does not pass a failed build", func(t *testing.T) {
+		// GetOk reports presence, so a step that stored a nil error must not be
+		// treated as a recorded failure; with no image_id the build still fails
+		// (rather than panicking on the type assertion or returning nil).
+		state := new(multistep.BasicStateBag)
+		var nilErr error
+		state.Put("error", nilErr)
+
+		if err := buildResultError(state); err == nil {
+			t.Fatal("expected a failure when error key holds nil and no image_id exists, got nil")
+		}
+	})
 }

--- a/builder/ibmcloud/vpc/step_capture_image.go
+++ b/builder/ibmcloud/vpc/step_capture_image.go
@@ -141,9 +141,15 @@ func (s *stepCaptureImage) Run(_ context.Context, state multistep.StateBag) mult
 
 		_, resp, err := serviceClientOptions.AttachTag(AttachTagOptions)
 		if err != nil {
-			errUserTags := fmt.Errorf("[ERROR] Error attaching tags %v : %s\n%s", config.ImageTags, err, resp)
-			state.Put("error", errUserTags)
-			ui.Say(errUserTags.Error())
+			// Tags were explicitly requested, so applying them is part of the build
+			// contract: fail loudly rather than emitting an untagged image. Halt here
+			// (consistent with the tagging-client failure above) instead of recording
+			// the error and continuing, which would leave the image and fail the build
+			// with a buried message after a pointless wait-for-AVAILABLE.
+			err := fmt.Errorf("[ERROR] Error attaching tags %v : %s\n%s", config.ImageTags, err, resp)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
 		}
 	}
 

--- a/builder/ibmcloud/vpc/step_capture_image.go
+++ b/builder/ibmcloud/vpc/step_capture_image.go
@@ -92,16 +92,13 @@ func (s *stepCaptureImage) Run(_ context.Context, state multistep.StateBag) mult
 
 	if err != nil {
 		err := fmt.Errorf("[ERROR] Error sending the HTTP request that creates the image. Error: %s", err)
-		ui.Error(err.Error())
-		log.Println(err.Error())
-		return multistep.ActionHalt
-	}
-
-	if err != nil {
-		err := fmt.Errorf("[ERROR] Error creating the Image: %s", err)
+		// Record the error under the "error" state-bag key (the convention every
+		// halting step follows) so the builder's Run surfaces this specific
+		// CreateImage failure via buildResultError, instead of the generic
+		// "no image_id" fallback.
 		state.Put("error", err)
 		ui.Error(err.Error())
-		// log.Fatalf(err.Error())
+		log.Println(err.Error())
 		return multistep.ActionHalt
 	}
 

--- a/builder/ibmcloud/vpc/step_capture_image.go
+++ b/builder/ibmcloud/vpc/step_capture_image.go
@@ -92,10 +92,10 @@ func (s *stepCaptureImage) Run(_ context.Context, state multistep.StateBag) mult
 
 	if err != nil {
 		err := fmt.Errorf("[ERROR] Error sending the HTTP request that creates the image. Error: %s", err)
-		// Record the error under the "error" state-bag key (the convention every
-		// halting step follows) so the builder's Run surfaces this specific
-		// CreateImage failure via buildResultError, instead of the generic
-		// "no image_id" fallback.
+		// Record the error under the "error" state-bag key (the convention the
+		// other halting steps here follow) so the builder's Run surfaces this
+		// specific CreateImage failure via buildResultError, instead of the
+		// generic "no image_id" fallback.
 		state.Put("error", err)
 		ui.Error(err.Error())
 		log.Println(err.Error())
@@ -141,11 +141,11 @@ func (s *stepCaptureImage) Run(_ context.Context, state multistep.StateBag) mult
 
 		_, resp, err := serviceClientOptions.AttachTag(AttachTagOptions)
 		if err != nil {
-			// Tags were explicitly requested, so applying them is part of the build
-			// contract: fail loudly rather than emitting an untagged image. Halt here
-			// (consistent with the tagging-client failure above) instead of recording
-			// the error and continuing, which would leave the image and fail the build
-			// with a buried message after a pointless wait-for-AVAILABLE.
+			// Tags were explicitly requested, so a tagging failure is a build
+			// failure: halt (like the tagging-client failure above) rather than
+			// returning the image as a successful artifact. (The image already
+			// exists at this point and is not deleted on halt; see the orphaned-image
+			// note in Cleanup.)
 			err := fmt.Errorf("[ERROR] Error attaching tags %v : %s\n%s", config.ImageTags, err, resp)
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -167,6 +167,9 @@ func (s *stepCaptureImage) Run(_ context.Context, state multistep.StateBag) mult
 }
 
 func (s *stepCaptureImage) Cleanup(state multistep.StateBag) {
+	// Note: this does not delete the captured image. If the build halts after
+	// CreateImage succeeds (e.g. tag attachment or the AVAILABLE wait fails), the
+	// image is left in the account and must be removed manually.
 	ui := state.Get("ui").(packer.Ui)
 	ui.Say("")
 	ui.Say("****************************************************************************")


### PR DESCRIPTION
## Summary

A VPC build that fails while **capturing the image** could finish with a **zero exit code and no artifact** — a false success. If `vpcService.CreateImage` returns an error (e.g. the image name is not unique, a transient API/auth failure, quota, an invalid source volume), the build prints `Builds finished but no artifacts were created.` and `packer build` exits **0**. Any automation that trusts the exit code then treats the broken bake as successful.

## The bug

Two defects combine:

1. **`step_capture_image.go` — the `CreateImage` error path never recorded the error.** On failure it called `ui.Error` / `log.Println` and returned `multistep.ActionHalt`, but did **not** `state.Put("error", err)`. `multistep.ActionHalt` only stops the step chain; it does not by itself fail the build. Every other halting step in this builder records the error under the `"error"` key first — this branch was the outlier. (There was also an unreachable second `if err != nil` block immediately after the first `return`, which ironically held the very `state.Put("error", err)` the live branch was missing.)

2. **`builder.go` — a halt with no image was reported as success.** After the runner finishes, `Run` checked `state["error"]` (never set, per defect 1) and then, finding no `image_id`, returned `(nil, nil)`. A builder returning `(nil, nil)` signals *succeeded, no artifact* to Packer, so the process exits 0.

## The fix

- **`step_capture_image.go`**: record `state.Put("error", err)` on the `CreateImage` failure, matching the convention every other halting step in this builder already follows. This surfaces the real, specific API error. The unreachable duplicate block is folded away.
- **`builder.go`**: extract `buildResultError(state)`. Reaching the end of `Run` without an `image_id` now returns a real error instead of `(nil, nil)`. This is defense-in-depth: any step that halts without recording an explicit `"error"` (a recurring defect class in this builder) can no longer produce a false success.
- **`builder_test.go`**: unit tests for `buildResultError` — recorded error is propagated, a halt with no image fails the build (the regression), and the happy path with an `image_id` succeeds.
- **`step_capture_image.go` (`AttachTag`)**: the optional image-tagging failure path recorded `state.Put("error", ...)` but surfaced it via `ui.Say` and did **not** halt — so it fell through to the wait-for-AVAILABLE and then failed the build with the cause buried in an informational message. Made it consistent with the tagging-client failure immediately above it (`ui.Error` + `return ActionHalt`). When `image_tags` are explicitly requested, applying them is part of the build contract, so a tagging failure is a real build failure rather than a best-effort warning.

## Why it's safe

- **Behavior-preserving on success.** A successful capture still sets `image_id` and returns the artifact unchanged. The only behavioral change is that a *failed* capture now fails the build (the intended Packer contract) instead of passing silently.
- **No new dependencies, no API changes.** `buildResultError` is a pure function over `multistep.StateBag`; the extraction preserves the original error-then-image_id precedence exactly.
- **Verified.** `go build ./...`, `go vet`, `go test ./builder/ibmcloud/vpc/`, and `gofmt` all pass.

## Related / follow-ups (not in this PR)

- This is the same *class* of defect as #152 (errors recorded under the wrong/no state-bag key → silent exit 0), in a different code path. The `buildResultError` safety net here also backstops those paths.
