### PR TITLE
fix(vpc): verify encryption_key_crn via the KMS API instead of Global Search

### DIFF
--- a/builder/ibmcloud/vpc/step_verify_input.go
+++ b/builder/ibmcloud/vpc/step_verify_input.go
@@ -213,7 +213,7 @@ func (s *stepVerifyInput) Run(_ context.Context, state multistep.StateBag) multi
 
 	// crn validation
 
-	if config.CatalogOfferingCRN != "" || config.CatalogOfferingVersionCRN != "" || config.EncryptionKeyCRN != "" {
+	if config.CatalogOfferingCRN != "" || config.CatalogOfferingVersionCRN != "" {
 		// validate crn
 
 		searchURL := "https://api.global-search-tagging.cloud.ibm.com"
@@ -260,23 +260,19 @@ func (s *stepVerifyInput) Run(_ context.Context, state multistep.StateBag) multi
 				return multistep.ActionHalt
 			}
 		}
-		// validate encryption key crn
-		if config.EncryptionKeyCRN != "" {
-			crnToCheck := fmt.Sprintf("%s%s", strings.Split(config.EncryptionKeyCRN, ":key")[0], "::")
-			query := fmt.Sprintf("crn:\"%s\"", crnToCheck)
-			searchOptions := &searchv2.SearchOptions{
-				Query: &query,
-			}
-			res, _, _ := globalSearchAPIV2.Search(searchOptions)
-			if len(res.Items) != 0 {
-				ui.Say(fmt.Sprintf("%s Encryption information successfully retrieved ...", res.Items[0].GetProperty("name")))
-			} else {
-				err := fmt.Errorf("[ERROR] Encryption crn (%s) information could not be retrieved", config.EncryptionKeyCRN)
-				state.Put("Encryption information could not be retrieved", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
+	}
+
+	// validate encryption key crn via the KMS API. Global Search does not index Key Protect or
+	// Hyper Protect Crypto Services instances, so the encryption key cannot be verified that way;
+	// read it from the KMS GET key endpoint (derived from the CRN's service) instead.
+	if config.EncryptionKeyCRN != "" {
+		if err := verifyEncryptionKeyCRN(config.EncryptionKeyCRN, newKMSKeyVerifier(client.IBMApiKey, config.IAMEndpoint)); err != nil {
+			err := fmt.Errorf("[ERROR] Encryption crn (%s) information could not be retrieved: %s", config.EncryptionKeyCRN, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
 		}
+		ui.Say("Encryption information successfully retrieved ...")
 	}
 	return multistep.ActionContinue
 }

--- a/builder/ibmcloud/vpc/verify_encryption_key.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key.go
@@ -1,0 +1,98 @@
+package vpc
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+)
+
+// keyVerifier reports whether the KMS key referenced by an encryption_key_crn exists and is
+// readable. It is a seam so the verification can be faked in tests.
+type keyVerifier interface {
+	keyExists(endpoint, instanceID, keyID string) (bool, error)
+}
+
+// parseEncryptionKeyCRN derives the KMS API endpoint, instance id, and key id from a Key Protect
+// or Hyper Protect Crypto Services key CRN. Key Protect keys are served from the regional KMS
+// endpoint; Hyper Protect Crypto Services keys are served from the per-instance endpoint.
+//
+// Expected CRN shape:
+//
+//	crn:v1:bluemix:public:<service>:<region>:a/<account>:<instance>:key:<keyID>
+func parseEncryptionKeyCRN(crn string) (endpoint, instanceID, keyID string, err error) {
+	p := strings.Split(crn, ":")
+	if len(p) < 10 || p[0] != "crn" || p[8] != "key" {
+		return "", "", "", fmt.Errorf("not a recognized Key Protect / Hyper Protect Crypto Services key CRN: %q", crn)
+	}
+	service, region, instanceID, keyID := p[4], p[5], p[7], p[9]
+	if region == "" || instanceID == "" || keyID == "" {
+		return "", "", "", fmt.Errorf("encryption key CRN is missing a region, instance, or key id: %q", crn)
+	}
+	switch service {
+	case "hs-crypto": // Hyper Protect Crypto Services: per-instance endpoint
+		endpoint = fmt.Sprintf("https://%s.api.%s.hs-crypto.appdomain.cloud", instanceID, region)
+	case "kms": // Key Protect: regional endpoint
+		endpoint = fmt.Sprintf("https://%s.kms.cloud.ibm.com", region)
+	default:
+		return "", "", "", fmt.Errorf("unsupported KMS service %q in encryption key CRN: %q", service, crn)
+	}
+	return endpoint, instanceID, keyID, nil
+}
+
+// kmsKeyVerifier reads a key through the Key Protect-compatible KMS API (GET /api/v2/keys/{id}).
+type kmsKeyVerifier struct {
+	authenticator core.Authenticator
+	client        *http.Client
+}
+
+// newKMSKeyVerifier builds a kmsKeyVerifier that authenticates with the build's IBM Cloud API key.
+func newKMSKeyVerifier(apiKey, iamURL string) kmsKeyVerifier {
+	return kmsKeyVerifier{
+		authenticator: &core.IamAuthenticator{ApiKey: apiKey, URL: iamURL},
+		client:        &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (v kmsKeyVerifier) keyExists(endpoint, instanceID, keyID string) (bool, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v2/keys/%s", endpoint, keyID), nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Accept", "application/vnd.ibm.kms.key+json")
+	req.Header.Set("Bluemix-Instance", instanceID)
+	if err := v.authenticator.Authenticate(req); err != nil {
+		return false, fmt.Errorf("authenticating KMS request: %w", err)
+	}
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("KMS GET key returned HTTP %d", resp.StatusCode)
+	}
+}
+
+// verifyEncryptionKeyCRN validates an encryption_key_crn by reading the key through the KMS API.
+func verifyEncryptionKeyCRN(crn string, v keyVerifier) error {
+	endpoint, instanceID, keyID, err := parseEncryptionKeyCRN(crn)
+	if err != nil {
+		return err
+	}
+	exists, err := v.keyExists(endpoint, instanceID, keyID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("key %s not found at %s", keyID, endpoint)
+	}
+	return nil
+}

--- a/builder/ibmcloud/vpc/verify_encryption_key.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -48,6 +49,8 @@ type kmsKeyVerifier struct {
 	client        *http.Client
 }
 
+var _ keyVerifier = kmsKeyVerifier{}
+
 // newKMSKeyVerifier builds a kmsKeyVerifier that authenticates with the build's IBM Cloud API key.
 func newKMSKeyVerifier(apiKey, iamURL string) kmsKeyVerifier {
 	return kmsKeyVerifier{
@@ -56,19 +59,23 @@ func newKMSKeyVerifier(apiKey, iamURL string) kmsKeyVerifier {
 	}
 }
 
+// keyExists reports whether the key is readable. 200 -> exists; 404 -> absent (or not visible to
+// this identity). Any other status is returned as an error so the build halts rather than
+// misreporting an auth/transport failure as a missing key; 401/403 are called out specifically
+// since they almost always mean the build's API key lacks reader access to the KMS instance.
 func (v kmsKeyVerifier) keyExists(endpoint, instanceID, keyID string) (bool, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v2/keys/%s", endpoint, keyID), nil)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("building KMS request for key %s: %w", keyID, err)
 	}
 	req.Header.Set("Accept", "application/vnd.ibm.kms.key+json")
 	req.Header.Set("Bluemix-Instance", instanceID)
 	if err := v.authenticator.Authenticate(req); err != nil {
-		return false, fmt.Errorf("authenticating KMS request: %w", err)
+		return false, fmt.Errorf("authenticating KMS request for key %s: %w", keyID, err)
 	}
 	resp, err := v.client.Do(req)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("contacting KMS at %s to verify key %s: %w", endpoint, keyID, err)
 	}
 	defer resp.Body.Close()
 	switch resp.StatusCode {
@@ -76,9 +83,19 @@ func (v kmsKeyVerifier) keyExists(endpoint, instanceID, keyID string) (bool, err
 		return true, nil
 	case http.StatusNotFound:
 		return false, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, fmt.Errorf("KMS denied access to key %s at %s (HTTP %d) — the build's API key likely lacks reader access to this Key Protect / Hyper Protect Crypto Services instance: %s",
+			keyID, endpoint, resp.StatusCode, kmsBodySnippet(resp))
 	default:
-		return false, fmt.Errorf("KMS GET key returned HTTP %d", resp.StatusCode)
+		return false, fmt.Errorf("KMS GET key %s at %s returned HTTP %d: %s", keyID, endpoint, resp.StatusCode, kmsBodySnippet(resp))
 	}
+}
+
+// kmsBodySnippet returns a bounded, single-line snippet of the response body so KMS's own error
+// message (e.g. resources[].errorMsg) shows up in the build log.
+func kmsBodySnippet(resp *http.Response) string {
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return strings.Join(strings.Fields(string(b)), " ")
 }
 
 // verifyEncryptionKeyCRN validates an encryption_key_crn by reading the key through the KMS API.
@@ -92,7 +109,7 @@ func verifyEncryptionKeyCRN(crn string, v keyVerifier) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("key %s not found at %s", keyID, endpoint)
+		return fmt.Errorf("key %s not found or not accessible at %s", keyID, endpoint)
 	}
 	return nil
 }

--- a/builder/ibmcloud/vpc/verify_encryption_key.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key.go
@@ -1,6 +1,7 @@
 package vpc
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,7 +44,7 @@ func parseEncryptionKeyCRN(crn string) (endpoint, instanceID, keyID string, err 
 	return endpoint, instanceID, keyID, nil
 }
 
-// kmsKeyVerifier reads a key through the Key Protect-compatible KMS API (GET /api/v2/keys/{id}).
+// kmsKeyVerifier checks for a key through the Key Protect-compatible KMS API.
 type kmsKeyVerifier struct {
 	authenticator core.Authenticator
 	client        *http.Client
@@ -59,46 +60,57 @@ func newKMSKeyVerifier(apiKey, iamURL string) kmsKeyVerifier {
 	}
 }
 
-// keyExists reports whether the key is readable. 200 -> exists; 404 -> absent (or not visible to
-// this identity). Any other status is returned as an error so the build halts rather than
-// misreporting an auth/transport failure as a missing key; 401/403 are called out specifically
-// since they almost always mean the build's API key lacks reader access to the KMS instance.
+// keyExists reports whether a key with keyID is present in the KMS instance. It LISTs the
+// instance's keys (GET /api/v2/keys) and matches by id rather than GET /api/v2/keys/{id}: reading
+// a specific key requires a higher privilege than listing, and the build identity only needs to
+// confirm the key exists — the boot-volume encryption itself is performed by the VPC service via a
+// Key Protect service-to-service authorization, not by this identity.
 func (v kmsKeyVerifier) keyExists(endpoint, instanceID, keyID string) (bool, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v2/keys/%s", endpoint, keyID), nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint+"/api/v2/keys", nil)
 	if err != nil {
-		return false, fmt.Errorf("building KMS request for key %s: %w", keyID, err)
+		return false, fmt.Errorf("building KMS list-keys request: %w", err)
 	}
-	req.Header.Set("Accept", "application/vnd.ibm.kms.key+json")
 	req.Header.Set("Bluemix-Instance", instanceID)
 	if err := v.authenticator.Authenticate(req); err != nil {
-		return false, fmt.Errorf("authenticating KMS request for key %s: %w", keyID, err)
+		return false, fmt.Errorf("authenticating KMS request: %w", err)
 	}
 	resp, err := v.client.Do(req)
 	if err != nil {
-		return false, fmt.Errorf("contacting KMS at %s to verify key %s: %w", endpoint, keyID, err)
+		return false, fmt.Errorf("contacting KMS at %s to list keys: %w", endpoint, err)
 	}
 	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return true, nil
-	case http.StatusNotFound:
-		return false, nil
+		// parsed below
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return false, fmt.Errorf("KMS denied access to key %s at %s (HTTP %d) — the build's API key likely lacks reader access to this Key Protect / Hyper Protect Crypto Services instance: %s",
-			keyID, endpoint, resp.StatusCode, kmsBodySnippet(resp))
+		return false, fmt.Errorf("KMS denied listing keys at %s (HTTP %d) — the build's API key likely lacks reader access to this Key Protect / Hyper Protect Crypto Services instance: %s",
+			endpoint, resp.StatusCode, oneLineSnippet(body))
 	default:
-		return false, fmt.Errorf("KMS GET key %s at %s returned HTTP %d: %s", keyID, endpoint, resp.StatusCode, kmsBodySnippet(resp))
+		return false, fmt.Errorf("KMS list keys at %s returned HTTP %d: %s", endpoint, resp.StatusCode, oneLineSnippet(body))
 	}
+	var out struct {
+		Resources []struct {
+			ID string `json:"id"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return false, fmt.Errorf("parsing KMS list-keys response from %s: %w", endpoint, err)
+	}
+	for _, r := range out.Resources {
+		if r.ID == keyID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-// kmsBodySnippet returns a bounded, single-line snippet of the response body so KMS's own error
-// message (e.g. resources[].errorMsg) shows up in the build log.
-func kmsBodySnippet(resp *http.Response) string {
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+// oneLineSnippet collapses a (response body) byte slice to a single-line string for error messages.
+func oneLineSnippet(b []byte) string {
 	return strings.Join(strings.Fields(string(b)), " ")
 }
 
-// verifyEncryptionKeyCRN validates an encryption_key_crn by reading the key through the KMS API.
+// verifyEncryptionKeyCRN validates an encryption_key_crn by confirming the key exists via the KMS API.
 func verifyEncryptionKeyCRN(crn string, v keyVerifier) error {
 	endpoint, instanceID, keyID, err := parseEncryptionKeyCRN(crn)
 	if err != nil {
@@ -109,7 +121,7 @@ func verifyEncryptionKeyCRN(crn string, v keyVerifier) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("key %s not found or not accessible at %s", keyID, endpoint)
+		return fmt.Errorf("key %s not found in the KMS instance at %s", keyID, endpoint)
 	}
 	return nil
 }

--- a/builder/ibmcloud/vpc/verify_encryption_key_test.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key_test.go
@@ -110,18 +110,18 @@ func TestKMSKeyVerifierKeyExists(t *testing.T) {
 		wantExists bool
 		wantErr    bool
 	}{
-		{name: "200 means the key exists", status: http.StatusOK, body: `{"resources":[{"id":"key-1"}]}`, wantExists: true},
-		{name: "404 means absent without an error", status: http.StatusNotFound, body: `{}`},
-		{name: "403 is an error, not absent", status: http.StatusForbidden, body: `{"resources":[{"errorMsg":"denied"}]}`, wantErr: true},
-		{name: "401 is an error, not absent", status: http.StatusUnauthorized, body: `{}`, wantErr: true},
+		{name: "key present in the list", status: http.StatusOK, body: `{"resources":[{"id":"other"},{"id":"key-1"}]}`, wantExists: true},
+		{name: "key absent from the list", status: http.StatusOK, body: `{"resources":[{"id":"other"}]}`, wantExists: false},
+		{name: "empty list", status: http.StatusOK, body: `{"resources":[]}`, wantExists: false},
+		{name: "403 is an error", status: http.StatusForbidden, body: `{"resources":[{"errorMsg":"denied"}]}`, wantErr: true},
+		{name: "401 is an error", status: http.StatusUnauthorized, body: `{}`, wantErr: true},
 		{name: "500 is an error", status: http.StatusInternalServerError, body: "boom", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var gotPath, gotAccept, gotInstance string
+			var gotPath, gotInstance string
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotPath = r.URL.Path
-				gotAccept = r.Header.Get("Accept")
 				gotInstance = r.Header.Get("Bluemix-Instance")
 				w.WriteHeader(tt.status)
 				_, _ = w.Write([]byte(tt.body))
@@ -137,14 +137,11 @@ func TestKMSKeyVerifierKeyExists(t *testing.T) {
 			if exists != tt.wantExists {
 				t.Fatalf("keyExists = %v, want %v", exists, tt.wantExists)
 			}
-			if gotPath != "/api/v2/keys/key-1" {
-				t.Errorf("request path = %q, want /api/v2/keys/key-1", gotPath)
+			if gotPath != "/api/v2/keys" {
+				t.Errorf("request path = %q, want /api/v2/keys", gotPath)
 			}
 			if gotInstance != "inst-9" {
 				t.Errorf("Bluemix-Instance header = %q, want inst-9", gotInstance)
-			}
-			if gotAccept != "application/vnd.ibm.kms.key+json" {
-				t.Errorf("Accept header = %q, want application/vnd.ibm.kms.key+json", gotAccept)
 			}
 		})
 	}

--- a/builder/ibmcloud/vpc/verify_encryption_key_test.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key_test.go
@@ -1,0 +1,94 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseEncryptionKeyCRN(t *testing.T) {
+	tests := []struct {
+		name, crn                 string
+		endpoint, instance, keyID string
+		wantErr                   bool
+	}{
+		{
+			name:     "key protect uses the regional endpoint",
+			crn:      "crn:v1:bluemix:public:kms:us-east:a/acc:inst-1:key:key-1",
+			endpoint: "https://us-east.kms.cloud.ibm.com", instance: "inst-1", keyID: "key-1",
+		},
+		{
+			name:     "hyper protect crypto services uses the per-instance endpoint",
+			crn:      "crn:v1:bluemix:public:hs-crypto:us-east:a/acc:inst-2:key:key-2",
+			endpoint: "https://inst-2.api.us-east.hs-crypto.appdomain.cloud", instance: "inst-2", keyID: "key-2",
+		},
+		{name: "instance crn (not a key) is rejected", crn: "crn:v1:bluemix:public:kms:us-east:a/acc:inst-1::", wantErr: true},
+		{name: "unsupported service is rejected", crn: "crn:v1:bluemix:public:cloud-object-storage:us-east:a/acc:inst:key:k", wantErr: true},
+		{name: "garbage is rejected", crn: "not-a-crn", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, instance, keyID, err := parseEncryptionKeyCRN(tt.crn)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got endpoint=%q", endpoint)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if endpoint != tt.endpoint || instance != tt.instance || keyID != tt.keyID {
+				t.Fatalf("got (%q, %q, %q), want (%q, %q, %q)", endpoint, instance, keyID, tt.endpoint, tt.instance, tt.keyID)
+			}
+		})
+	}
+}
+
+type fakeKeyVerifier struct {
+	exists                           bool
+	err                              error
+	called                           bool
+	gotEndpoint, gotInstance, gotKey string
+}
+
+func (f *fakeKeyVerifier) keyExists(endpoint, instanceID, keyID string) (bool, error) {
+	f.called = true
+	f.gotEndpoint, f.gotInstance, f.gotKey = endpoint, instanceID, keyID
+	return f.exists, f.err
+}
+
+func TestVerifyEncryptionKeyCRN(t *testing.T) {
+	const crn = "crn:v1:bluemix:public:hs-crypto:us-east:a/acc:inst-2:key:key-2"
+
+	t.Run("key exists", func(t *testing.T) {
+		f := &fakeKeyVerifier{exists: true}
+		if err := verifyEncryptionKeyCRN(crn, f); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if f.gotEndpoint != "https://inst-2.api.us-east.hs-crypto.appdomain.cloud" || f.gotInstance != "inst-2" || f.gotKey != "key-2" {
+			t.Fatalf("verifier got (%q, %q, %q)", f.gotEndpoint, f.gotInstance, f.gotKey)
+		}
+	})
+
+	t.Run("key not found is an error", func(t *testing.T) {
+		if err := verifyEncryptionKeyCRN(crn, &fakeKeyVerifier{exists: false}); err == nil {
+			t.Fatal("expected an error when the key is not found")
+		}
+	})
+
+	t.Run("verifier error is propagated", func(t *testing.T) {
+		if err := verifyEncryptionKeyCRN(crn, &fakeKeyVerifier{err: fmt.Errorf("boom")}); err == nil {
+			t.Fatal("expected the verifier error to propagate")
+		}
+	})
+
+	t.Run("malformed crn short-circuits before the verifier", func(t *testing.T) {
+		f := &fakeKeyVerifier{exists: true}
+		if err := verifyEncryptionKeyCRN("garbage", f); err == nil {
+			t.Fatal("expected a parse error")
+		}
+		if f.called {
+			t.Fatal("verifier must not be called for a malformed CRN")
+		}
+	})
+}

--- a/builder/ibmcloud/vpc/verify_encryption_key_test.go
+++ b/builder/ibmcloud/vpc/verify_encryption_key_test.go
@@ -2,6 +2,8 @@ package vpc
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -91,4 +93,66 @@ func TestVerifyEncryptionKeyCRN(t *testing.T) {
 			t.Fatal("verifier must not be called for a malformed CRN")
 		}
 	})
+}
+
+// stubAuthenticator is a no-op core.Authenticator for exercising kmsKeyVerifier against httptest.
+type stubAuthenticator struct{ err error }
+
+func (s stubAuthenticator) AuthenticationType() string       { return "stub" }
+func (s stubAuthenticator) Validate() error                  { return nil }
+func (s stubAuthenticator) Authenticate(*http.Request) error { return s.err }
+
+func TestKMSKeyVerifierKeyExists(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantExists bool
+		wantErr    bool
+	}{
+		{name: "200 means the key exists", status: http.StatusOK, body: `{"resources":[{"id":"key-1"}]}`, wantExists: true},
+		{name: "404 means absent without an error", status: http.StatusNotFound, body: `{}`},
+		{name: "403 is an error, not absent", status: http.StatusForbidden, body: `{"resources":[{"errorMsg":"denied"}]}`, wantErr: true},
+		{name: "401 is an error, not absent", status: http.StatusUnauthorized, body: `{}`, wantErr: true},
+		{name: "500 is an error", status: http.StatusInternalServerError, body: "boom", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotAccept, gotInstance string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAccept = r.Header.Get("Accept")
+				gotInstance = r.Header.Get("Bluemix-Instance")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			v := kmsKeyVerifier{authenticator: stubAuthenticator{}, client: srv.Client()}
+			exists, err := v.keyExists(srv.URL, "inst-9", "key-1")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("keyExists error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if exists != tt.wantExists {
+				t.Fatalf("keyExists = %v, want %v", exists, tt.wantExists)
+			}
+			if gotPath != "/api/v2/keys/key-1" {
+				t.Errorf("request path = %q, want /api/v2/keys/key-1", gotPath)
+			}
+			if gotInstance != "inst-9" {
+				t.Errorf("Bluemix-Instance header = %q, want inst-9", gotInstance)
+			}
+			if gotAccept != "application/vnd.ibm.kms.key+json" {
+				t.Errorf("Accept header = %q, want application/vnd.ibm.kms.key+json", gotAccept)
+			}
+		})
+	}
+}
+
+func TestKMSKeyVerifierAuthenticateError(t *testing.T) {
+	v := kmsKeyVerifier{authenticator: stubAuthenticator{err: fmt.Errorf("no token")}, client: http.DefaultClient}
+	if _, err := v.keyExists("https://example.invalid", "inst-9", "key-1"); err == nil {
+		t.Fatal("expected an error when authentication fails")
+	}
 }


### PR DESCRIPTION
## Summary

The `vpc` builder validates `encryption_key_crn` by querying IBM **Global Search** for the key's instance CRN. But Global Search does not index Key Protect or Hyper Protect Crypto Services instances, so the lookup returns nothing and the build halts with `Encryption crn (...) information could not be retrieved` for **every** encryption key — regardless of IAM access. (Observed on a real encrypted bake: Global Search for `service_name:kms` and `service_name:hs-crypto` both return 0 results, while `service_name:is` returns VPC resources fine.)

## What changed

`step_verify_input.go` now validates `encryption_key_crn` against the Key Protect-compatible KMS API instead of Global Search. It **LISTs the instance's keys** (`GET /api/v2/keys`, endpoint derived from the CRN's service — `kms` → regional `https://<region>.kms.cloud.ibm.com`, `hs-crypto` → per-instance `https://<instance>.api.<region>.hs-crypto.appdomain.cloud`) and matches the target key id.

It LISTs rather than `GET /api/v2/keys/{id}` deliberately: reading a specific key requires a **higher** Key Protect privilege than listing — observed in practice, an identity that can LIST an instance's keys (and see the target key + its CRN) still gets `401` on get-key. The build identity only needs to confirm the key **exists**; the boot-volume encryption itself is performed by the VPC service via a Key Protect service-to-service authorization, not by this identity. So LIST works with the lower (and sufficient) privilege.

The KMS call sits behind a small `keyVerifier` interface (new `verify_encryption_key.go`) so the CRN parsing and verification flow are unit-tested without a live API. Catalog-offering CRN validation is unchanged (still Global Search — catalog offerings are indexed there).

## Why it's safe

- **Same fail-loud contract**: a key that can't be confirmed still halts the build (via `state.Put("error", ...)`); `401`/`403` (likely missing reader access) and other non-200s return distinct, body-bearing errors.
- **No new third-party dependencies** — reuses the existing `go-sdk-core/v5` authenticator + `net/http` + stdlib `encoding/json`.
- **Tests**: cover Key Protect vs HPCS endpoint derivation, malformed CRNs, and the list paths (key present / absent / empty list / 401 / 403 / 5xx), asserting the request hits `/api/v2/keys` with the `Bluemix-Instance` header. `go build`, `go vet`, `go test ./builder/ibmcloud/vpc/...` pass; `gofmt` clean.
