### PR TITLE
feat(vpc): add subnet_ids for multi-zone capacity fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ type | string |  | Set it as "ibmcloud"
 | |
 api_key | string | Required | The IBM Cloud platform API key.
 region | string | Required | IBM Cloud region where VPC is deployed.
-subnet_id | string | Required | The VPC Subnet identifier. Required.
+subnet_id | string | Required* | The VPC Subnet identifier. Provide exactly one of `subnet_id` or `subnet_ids`.
+| OR |
+subnet_ids | list(string) | Required* | Candidate VPC Subnets. The builder tries them in a random order and falls through to the next when a zone cannot place the builder instance for a capacity reason (e.g. `cannot_start_capacity`). All subnets must belong to the same VPC. Provide exactly one of `subnet_id` or `subnet_ids`.
 | |
 resource_group_id | string | Optional | The resource group identifier to use. If not specified, IBM packer plugin uses `default` resource group.
 | OR |

--- a/builder/ibmcloud/vpc/client.go
+++ b/builder/ibmcloud/vpc/client.go
@@ -39,6 +39,58 @@ type IBMCloudClient struct {
 	IBMApiKey string
 }
 
+// capacityStatusReasonCodes are the instance status-reason codes that mean the
+// zone could not place the instance for a capacity / host-placement reason.
+// These surface at instance start (the instance is created, then goes to
+// "failed"), so a build that supplies several subnets can delete the failed
+// instance and retry in another zone. Other failure codes (e.g.
+// encryption_key_deleted) are not capacity-related and are not retried.
+var capacityStatusReasonCodes = map[string]bool{
+	vpcv1.InstanceStatusReasonCodeCannotStartCapacityConst:            true,
+	vpcv1.InstanceStatusReasonCodeCannotStartComputeConst:             true,
+	vpcv1.InstanceStatusReasonCodeCannotStartPlacementGroupConst:      true,
+	vpcv1.InstanceStatusReasonCodeCannotStartReservationCapacityConst: true,
+}
+
+// capacityError marks an instance-start failure that a different zone might
+// satisfy. stepCreateInstance uses errors.As to decide whether to fall through
+// to the next subnet.
+type capacityError struct{ msg string }
+
+func (e *capacityError) Error() string { return e.msg }
+
+// newInstanceFailedError builds the error for an instance that reached the
+// "failed" status. When the first status reason is a capacity / host-placement
+// code it returns a *capacityError (retry another zone); otherwise a plain error
+// that aborts the build.
+func newInstanceFailedError(reasons []vpcv1.InstanceStatusReason) error {
+	if len(reasons) == 0 {
+		return fmt.Errorf("[ERROR] Instance returned failed status with no status reason")
+	}
+	// Prefer a capacity reason from any slot so fallback still triggers when the
+	// capacity code isn't the primary reason; IBM usually returns one reason, but
+	// the ordering isn't guaranteed.
+	chosen, isCapacity := reasons[0], false
+	for _, r := range reasons {
+		if r.Code != nil && capacityStatusReasonCodes[*r.Code] {
+			chosen, isCapacity = r, true
+			break
+		}
+	}
+	code, message := "", ""
+	if chosen.Code != nil {
+		code = *chosen.Code
+	}
+	if chosen.Message != nil {
+		message = *chosen.Message
+	}
+	full := fmt.Sprintf("[ERROR] Instance returned failed status. Status Reason - %s: %s", code, message)
+	if isCapacity {
+		return &capacityError{msg: full}
+	}
+	return fmt.Errorf("%s", full)
+}
+
 func (client IBMCloudClient) New(IBMApiKey string) *IBMCloudClient {
 	return &IBMCloudClient{
 		http: &http.Client{
@@ -127,8 +179,7 @@ func (client IBMCloudClient) isResourceReady(resourceID string, resourceType str
 		}
 		status := *instance.Status
 		if status == "failed" {
-			err := fmt.Errorf("[ERROR] Instance return with failed status. Status Reason - %s: %s", status, *instance.StatusReasons[0].Message)
-			return false, err
+			return false, newInstanceFailedError(instance.StatusReasons)
 		}
 		ready = status == "running"
 		return ready, err

--- a/builder/ibmcloud/vpc/client_test.go
+++ b/builder/ibmcloud/vpc/client_test.go
@@ -1,6 +1,7 @@
 package vpc
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -175,5 +176,51 @@ func TestVPCServiceDoesNotRetryFatalErrors(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Errorf("expected exactly one request for a fatal 404, got %d", got)
+	}
+}
+
+// TestNewInstanceFailedError verifies that only capacity/host-placement status
+// reasons are classified as *capacityError (which drives subnet fallback); every
+// other failure — and an empty reason list — is a plain, fatal error.
+func TestNewInstanceFailedError(t *testing.T) {
+	reason := func(code string) vpcv1.InstanceStatusReason {
+		msg := "detail for " + code
+		return vpcv1.InstanceStatusReason{Code: &code, Message: &msg}
+	}
+	reasons := func(codes ...string) []vpcv1.InstanceStatusReason {
+		out := make([]vpcv1.InstanceStatusReason, 0, len(codes))
+		for _, c := range codes {
+			out = append(out, reason(c))
+		}
+		return out
+	}
+
+	tests := []struct {
+		name         string
+		reasons      []vpcv1.InstanceStatusReason
+		wantCapacity bool
+	}{
+		{"cannot_start_capacity", reasons(vpcv1.InstanceStatusReasonCodeCannotStartCapacityConst), true},
+		{"cannot_start_compute", reasons(vpcv1.InstanceStatusReasonCodeCannotStartComputeConst), true},
+		{"cannot_start_placement_group", reasons(vpcv1.InstanceStatusReasonCodeCannotStartPlacementGroupConst), true},
+		{"cannot_start_reservation_capacity", reasons(vpcv1.InstanceStatusReasonCodeCannotStartReservationCapacityConst), true},
+		{"encryption_key_deleted is fatal", reasons("encryption_key_deleted"), false},
+		{"generic cannot_start is fatal", reasons(vpcv1.InstanceStatusReasonCodeCannotStartConst), false},
+		{"empty reasons is fatal", nil, false},
+		{"nil code is fatal, no panic", []vpcv1.InstanceStatusReason{{Code: nil, Message: nil}}, false},
+		{"capacity in a later slot still triggers fallback", reasons("encryption_key_deleted", vpcv1.InstanceStatusReasonCodeCannotStartCapacityConst), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newInstanceFailedError(tc.reasons)
+			if err == nil {
+				t.Fatal("newInstanceFailedError returned nil, want an error")
+			}
+			var capErr *capacityError
+			if got := errors.As(err, &capErr); got != tc.wantCapacity {
+				t.Errorf("errors.As(*capacityError) = %v, want %v (err=%v)", got, tc.wantCapacity, err)
+			}
+		})
 	}
 }

--- a/builder/ibmcloud/vpc/config.go
+++ b/builder/ibmcloud/vpc/config.go
@@ -19,38 +19,39 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	IBMApiKey                 string `mapstructure:"api_key"`
-	Region                    string `mapstructure:"region"`
-	Endpoint                  string `mapstructure:"vpc_endpoint_url"`
-	RCEndpoint                string `mapstructure:"rc_endpoint_url"`
-	GhostEndpoint             string `mapstructure:"ghost_endpoint_url"`
-	EncryptionKeyCRN          string `mapstructure:"encryption_key_crn"`
-	IAMEndpoint               string `mapstructure:"iam_url"`
-	Zone                      string `mapstructure-to-hcl2:",skip"`
-	VPCID                     string `mapstructure-to-hcl2:",skip"`
-	SubnetID                  string `mapstructure:"subnet_id"`
-	SshKeyType                string `mapstructure:"ssh_key_type"`
-	CatalogOfferingCRN        string `mapstructure:"catalog_offering_crn"`
-	CatalogOfferingVersionCRN string `mapstructure:"catalog_offering_version_crn"`
-	ResourceGroupID           string `mapstructure:"resource_group_id"`
-	ResourceGroupName         string `mapstructure:"resource_group_name"`
-	SecurityGroupID           string `mapstructure:"security_group_id"`
-	VSIBaseImageID            string `mapstructure:"vsi_base_image_id"`
-	VSIBaseImageName          string `mapstructure:"vsi_base_image_name"`
-	VSIBootCapacity           int    `mapstructure:"vsi_boot_vol_capacity"`
-	VSIBootProfile            string `mapstructure:"vsi_boot_vol_profile"`
-	VSIBootIops               int    `mapstructure:"vsi_boot_vol_iops"`
-	VSIBootBandwidth          int    `mapstructure:"vsi_boot_vol_bandwidth"`
-	VSIBootVolumeID           string `mapstructure:"vsi_boot_volume_id"`
-	VSIBootSnapshotID         string `mapstructure:"vsi_boot_snapshot_id"`
-	VSIDataCapacity           int    `mapstructure:"vsi_data_vol_capacity"`
-	VSIDataProfile            string `mapstructure:"vsi_data_vol_profile"`
-	VSIDataIops               int    `mapstructure:"vsi_data_vol_iops"`
-	VSIDataBandwidth          int    `mapstructure:"vsi_data_vol_bandwidth"`
-	VSIProfile                string `mapstructure:"vsi_profile"`
-	VSIInterface              string `mapstructure:"vsi_interface"`
-	VSIUserDataFile           string `mapstructure:"vsi_user_data_file"`
-	VSIUserDataString         string `mapstructure:"vsi_user_data"`
+	IBMApiKey                 string   `mapstructure:"api_key"`
+	Region                    string   `mapstructure:"region"`
+	Endpoint                  string   `mapstructure:"vpc_endpoint_url"`
+	RCEndpoint                string   `mapstructure:"rc_endpoint_url"`
+	GhostEndpoint             string   `mapstructure:"ghost_endpoint_url"`
+	EncryptionKeyCRN          string   `mapstructure:"encryption_key_crn"`
+	IAMEndpoint               string   `mapstructure:"iam_url"`
+	Zone                      string   `mapstructure-to-hcl2:",skip"`
+	VPCID                     string   `mapstructure-to-hcl2:",skip"`
+	SubnetID                  string   `mapstructure:"subnet_id"`
+	SubnetIDs                 []string `mapstructure:"subnet_ids"`
+	SshKeyType                string   `mapstructure:"ssh_key_type"`
+	CatalogOfferingCRN        string   `mapstructure:"catalog_offering_crn"`
+	CatalogOfferingVersionCRN string   `mapstructure:"catalog_offering_version_crn"`
+	ResourceGroupID           string   `mapstructure:"resource_group_id"`
+	ResourceGroupName         string   `mapstructure:"resource_group_name"`
+	SecurityGroupID           string   `mapstructure:"security_group_id"`
+	VSIBaseImageID            string   `mapstructure:"vsi_base_image_id"`
+	VSIBaseImageName          string   `mapstructure:"vsi_base_image_name"`
+	VSIBootCapacity           int      `mapstructure:"vsi_boot_vol_capacity"`
+	VSIBootProfile            string   `mapstructure:"vsi_boot_vol_profile"`
+	VSIBootIops               int      `mapstructure:"vsi_boot_vol_iops"`
+	VSIBootBandwidth          int      `mapstructure:"vsi_boot_vol_bandwidth"`
+	VSIBootVolumeID           string   `mapstructure:"vsi_boot_volume_id"`
+	VSIBootSnapshotID         string   `mapstructure:"vsi_boot_snapshot_id"`
+	VSIDataCapacity           int      `mapstructure:"vsi_data_vol_capacity"`
+	VSIDataProfile            string   `mapstructure:"vsi_data_vol_profile"`
+	VSIDataIops               int      `mapstructure:"vsi_data_vol_iops"`
+	VSIDataBandwidth          int      `mapstructure:"vsi_data_vol_bandwidth"`
+	VSIProfile                string   `mapstructure:"vsi_profile"`
+	VSIInterface              string   `mapstructure:"vsi_interface"`
+	VSIUserDataFile           string   `mapstructure:"vsi_user_data_file"`
+	VSIUserDataString         string   `mapstructure:"vsi_user_data"`
 
 	ImageName string   `mapstructure:"image_name"`
 	ImageTags []string `mapstructure:"tags"`
@@ -116,8 +117,26 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.RCEndpoint = "https://resource-controller.cloud.ibm.com"
 	}
 
-	if c.SubnetID == "" {
-		errs = packer.MultiErrorAppend(errs, errors.New("a subnet_id must be specified"))
+	// Exactly one of subnet_id / subnet_ids. subnet_ids is the multi-zone form:
+	// the builder tries each subnet in turn, falling through to the next when a
+	// zone has no host capacity for the profile (see capacityStatusReasonCodes).
+	// subnet_id remains the single-subnet form.
+	switch {
+	case len(c.SubnetIDs) > 0 && c.SubnetID != "":
+		errs = packer.MultiErrorAppend(errs, errors.New("only one of subnet_id or subnet_ids can be specified"))
+	case len(c.SubnetIDs) == 0 && c.SubnetID == "":
+		errs = packer.MultiErrorAppend(errs, errors.New("a subnet_id or subnet_ids must be specified"))
+	}
+	for _, id := range c.SubnetIDs {
+		if id == "" {
+			errs = packer.MultiErrorAppend(errs, errors.New("subnet_ids must not contain empty entries"))
+			break
+		}
+	}
+	// Normalize to the list form: the build steps read SubnetIDs exclusively.
+	// subnet_id is left set for config round-tripping but is no longer read.
+	if len(c.SubnetIDs) == 0 && c.SubnetID != "" {
+		c.SubnetIDs = []string{c.SubnetID}
 	}
 
 	if c.VSIBootCapacity != 0 && (c.VSIBootCapacity < 10 || c.VSIBootCapacity > 32000) {

--- a/builder/ibmcloud/vpc/config.hcl2spec.go
+++ b/builder/ibmcloud/vpc/config.hcl2spec.go
@@ -75,6 +75,7 @@ type FlatConfig struct {
 	EncryptionKeyCRN                   *string           `mapstructure:"encryption_key_crn" cty:"encryption_key_crn" hcl:"encryption_key_crn"`
 	IAMEndpoint                        *string           `mapstructure:"iam_url" cty:"iam_url" hcl:"iam_url"`
 	SubnetID                           *string           `mapstructure:"subnet_id" cty:"subnet_id" hcl:"subnet_id"`
+	SubnetIDs                          []string          `mapstructure:"subnet_ids" cty:"subnet_ids" hcl:"subnet_ids"`
 	SshKeyType                         *string           `mapstructure:"ssh_key_type" cty:"ssh_key_type" hcl:"ssh_key_type"`
 	CatalogOfferingCRN                 *string           `mapstructure:"catalog_offering_crn" cty:"catalog_offering_crn" hcl:"catalog_offering_crn"`
 	CatalogOfferingVersionCRN          *string           `mapstructure:"catalog_offering_version_crn" cty:"catalog_offering_version_crn" hcl:"catalog_offering_version_crn"`
@@ -191,6 +192,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"encryption_key_crn":                      &hcldec.AttrSpec{Name: "encryption_key_crn", Type: cty.String, Required: false},
 		"iam_url":                                 &hcldec.AttrSpec{Name: "iam_url", Type: cty.String, Required: false},
 		"subnet_id":                               &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"subnet_ids":                              &hcldec.AttrSpec{Name: "subnet_ids", Type: cty.List(cty.String), Required: false},
 		"ssh_key_type":                            &hcldec.AttrSpec{Name: "ssh_key_type", Type: cty.String, Required: false},
 		"catalog_offering_crn":                    &hcldec.AttrSpec{Name: "catalog_offering_crn", Type: cty.String, Required: false},
 		"catalog_offering_version_crn":            &hcldec.AttrSpec{Name: "catalog_offering_version_crn", Type: cty.String, Required: false},

--- a/builder/ibmcloud/vpc/config_test.go
+++ b/builder/ibmcloud/vpc/config_test.go
@@ -600,3 +600,73 @@ func TestDataVolumeAttachments(t *testing.T) {
 		}
 	})
 }
+
+// TestPrepareSubnetSelection covers the mutual exclusion between subnet_id and
+// subnet_ids, empty-entry rejection, and normalization of a lone subnet_id into
+// the list form the build steps read.
+func TestPrepareSubnetSelection(t *testing.T) {
+	cases := []struct {
+		name        string
+		subnetID    string
+		subnetIDs   []string
+		wantErr     string // substring expected in the error, "" means accept
+		wantSubnets []string
+	}{
+		{
+			name:        "only subnet_id normalizes to list",
+			subnetID:    "0717-subnet-a",
+			wantSubnets: []string{"0717-subnet-a"},
+		},
+		{
+			name:        "only subnet_ids is kept",
+			subnetIDs:   []string{"0717-subnet-a", "0727-subnet-b"},
+			wantSubnets: []string{"0717-subnet-a", "0727-subnet-b"},
+		},
+		{
+			name:      "both set is rejected",
+			subnetID:  "0717-subnet-a",
+			subnetIDs: []string{"0727-subnet-b"},
+			wantErr:   "only one of subnet_id or subnet_ids",
+		},
+		{
+			name:    "neither set is rejected",
+			wantErr: "a subnet_id or subnet_ids must be specified",
+		},
+		{
+			name:      "empty entry in subnet_ids is rejected",
+			subnetIDs: []string{"0717-subnet-a", ""},
+			wantErr:   "subnet_ids must not contain empty entries",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validVPCConfig()
+			// validVPCConfig omits ssh_username; set it so a valid case yields a
+			// clean Prepare and the normalization assertion isn't masked.
+			c.Comm.SSHUsername = "root"
+			c.SubnetID = tc.subnetID
+			c.SubnetIDs = tc.subnetIDs
+
+			_, err := c.Prepare()
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Prepare() error = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Prepare() unexpected error: %v", err)
+			}
+			if len(c.SubnetIDs) != len(tc.wantSubnets) {
+				t.Fatalf("SubnetIDs = %v, want %v", c.SubnetIDs, tc.wantSubnets)
+			}
+			for i, want := range tc.wantSubnets {
+				if c.SubnetIDs[i] != want {
+					t.Errorf("SubnetIDs[%d] = %q, want %q", i, c.SubnetIDs[i], want)
+				}
+			}
+		})
+	}
+}

--- a/builder/ibmcloud/vpc/step_create_instance.go
+++ b/builder/ibmcloud/vpc/step_create_instance.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -16,11 +17,76 @@ type stepCreateInstance struct{}
 func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(Config)
 	ui := state.Get("ui").(packer.Ui)
+	client := state.Get("client").(*IBMCloudClient)
 
-	var vpcService *vpcv1.VpcV1
-	if state.Get("vpcService") != nil {
-		vpcService = state.Get("vpcService").(*vpcv1.VpcV1)
+	// bake_subnets is the shuffled subnet/zone list from stepGetSubnetInfo. The
+	// builder VSI's profile can intermittently have no host capacity in a given
+	// zone (a capacity status reason; see capacityStatusReasonCodes), so try each
+	// subnet in turn: create the VSI, wait for it to start, and on a capacity
+	// failure delete it and move to the next zone.
+	subnets := state.Get("bake_subnets").([]subnetZone)
+
+	for i, sn := range subnets {
+		if len(subnets) > 1 {
+			ui.Say(fmt.Sprintf("Creating Instance in subnet %s (zone %s) [attempt %d/%d]...", sn.ID, sn.Zone, i+1, len(subnets)))
+		} else {
+			ui.Say("Creating Instance...")
+		}
+
+		instanceData, err := step.createInstance(state, sn.ID, sn.Zone)
+		if err != nil {
+			// A create-time error is not the capacity case, so it is fatal rather
+			// than retried in another zone.
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		// Record the instance immediately so Cleanup can delete it if the wait
+		// below fails on the final attempt.
+		state.Put("instance_data", instanceData)
+		ui.Say(fmt.Sprintf("Instance created: %s (%s). Waiting for it to start...", *instanceData.Name, *instanceData.ID))
+
+		waitErr := client.waitForResourceReady(*instanceData.ID, "instances", config.StateTimeout, state)
+		if waitErr == nil {
+			ui.Say("Instance successfully started!")
+			return multistep.ActionContinue
+		}
+
+		// Only a capacity/host-placement failure is worth trying another zone; any
+		// other failure (and the last subnet) is fatal.
+		var capErr *capacityError
+		if !errors.As(waitErr, &capErr) || i == len(subnets)-1 {
+			state.Put("error", waitErr)
+			ui.Error(waitErr.Error())
+			return multistep.ActionHalt
+		}
+
+		ui.Say(fmt.Sprintf("Zone %s could not start the instance (%s). Trying the next subnet...", sn.Zone, waitErr))
+		// Delete the failed VSI before the next attempt, then clear instance_data
+		// so Cleanup does not try to delete an instance that is already gone.
+		if delErr := deleteInstanceAndWait(vpcService(state), ui, *instanceData.ID, config.StateTimeout); delErr != nil {
+			state.Put("error", delErr)
+			ui.Error(delErr.Error())
+			return multistep.ActionHalt
+		}
+		state.Put("instance_data", nil)
 	}
+
+	// Unreachable: Config.Prepare guarantees at least one subnet.
+	err := fmt.Errorf("[ERROR] no subnets were available to create the builder instance")
+	state.Put("error", err)
+	ui.Error(err.Error())
+	return multistep.ActionHalt
+}
+
+// createInstance builds the instance prototype for the configured source
+// (catalog offering, base image, boot volume, or boot snapshot) in the given
+// subnet/zone and creates it. It returns the created instance or an error; it
+// does not wait for the instance to start or mutate build state beyond recording
+// the instance definition.
+func (step *stepCreateInstance) createInstance(state multistep.StateBag, subnetID, zone string) (*vpcv1.Instance, error) {
+	config := state.Get("config").(Config)
+	svc := vpcService(state)
 
 	vsiBaseImageName := config.VSIBaseImageName
 	vsiBaseImageID := state.Get("baseImageID").(string)
@@ -41,21 +107,18 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		ID: &[]string{state.Get("vpc_id").(string)}[0],
 	}
 	subnetIdentityModel := &vpcv1.SubnetIdentityByID{
-		ID: &[]string{config.SubnetID}[0],
+		ID: &[]string{subnetID}[0],
 	}
 	networkInterfacePrototypeModel := &vpcv1.NetworkInterfacePrototype{
 		Name:   &[]string{"my-instance-modified"}[0],
 		Subnet: subnetIdentityModel,
 	}
 	zoneIdentityModel := &vpcv1.ZoneIdentityByName{
-		Name: &[]string{state.Get("zone").(string)}[0],
+		Name: &[]string{zone}[0],
 	}
-
-	ui.Say("Creating Instance...")
 
 	// For catalog images
 	if vsiCatalogOfferingCrn != "" || vsiCatalogOfferingVersionCrn != "" {
-
 		catalogOfferingPrototype := &vpcv1.InstanceCatalogOfferingPrototype{}
 
 		// offering crn
@@ -86,56 +149,16 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		instancePrototypeModel.VolumeAttachments = dataVolumeAttachments(&config)
 		instancePrototypeModel.CatalogOffering = catalogOfferingPrototype
 
-		userDataFilePath := config.VSIUserDataFile
-		userDataString := config.VSIUserDataString
-		if userDataFilePath != "" {
-			content, err := os.ReadFile(userDataFilePath)
-			if err != nil {
-				err := fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-			instancePrototypeModel.UserData = &[]string{string(content)}[0]
-		} else if userDataString != "" {
-			instancePrototypeModel.UserData = &[]string{string(userDataString)}[0]
+		if err := applyUserData(&config, &instancePrototypeModel.UserData); err != nil {
+			return nil, err
 		}
-
-		if config.ResourceGroupID != "" {
-			instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-				ID: &config.ResourceGroupID,
-			}
-		} else if config.ResourceGroupName != "" {
-			derivedResourceGroupId := state.Get("derived_resource_group_id")
-			if derivedResourceGroupId != nil && derivedResourceGroupId.(string) != "" {
-				derivedResourceGroupIdStr := derivedResourceGroupId.(string)
-				instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-					ID: &derivedResourceGroupIdStr,
-				}
-			}
-		}
+		instancePrototypeModel.ResourceGroup = resourceGroupIdentity(&config, state)
 
 		state.Put("instance_definition", *instancePrototypeModel)
+		return doCreate(svc, instancePrototypeModel)
+	}
 
-		createInstanceOptions := vpcService.NewCreateInstanceOptions(
-			instancePrototypeModel,
-		)
-		instanceData, _, err := vpcService.CreateInstance(createInstanceOptions)
-		// End
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error creating the instance: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			// log.Fatalf(err.Error())
-			return multistep.ActionHalt
-		}
-		state.Put("instance_data", instanceData)
-		ui.Say("Instance successfully created!")
-		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
-		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
-
-	} else if vsiBaseImageName != "" || vsiBaseImageID != "" {
-
+	if vsiBaseImageName != "" || vsiBaseImageID != "" {
 		imageIdentityModel := &vpcv1.ImageIdentityByID{
 			ID: &[]string{vsiBaseImageID}[0],
 		}
@@ -155,57 +178,16 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		}
 		instancePrototypeModel.VolumeAttachments = dataVolumeAttachments(&config)
 
-		userDataFilePath := config.VSIUserDataFile
-		userDataString := config.VSIUserDataString
-		if userDataFilePath != "" {
-			content, err := os.ReadFile(userDataFilePath)
-			if err != nil {
-				err := fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-			instancePrototypeModel.UserData = &[]string{string(content)}[0]
-		} else if userDataString != "" {
-			instancePrototypeModel.UserData = &[]string{string(userDataString)}[0]
+		if err := applyUserData(&config, &instancePrototypeModel.UserData); err != nil {
+			return nil, err
 		}
-
-		if config.ResourceGroupID != "" {
-			instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-				ID: &config.ResourceGroupID,
-			}
-		} else if config.ResourceGroupName != "" {
-			derivedResourceGroupId := state.Get("derived_resource_group_id")
-			if derivedResourceGroupId != nil && derivedResourceGroupId.(string) != "" {
-				derivedResourceGroupIdStr := derivedResourceGroupId.(string)
-				instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-					ID: &derivedResourceGroupIdStr,
-				}
-			}
-		}
+		instancePrototypeModel.ResourceGroup = resourceGroupIdentity(&config, state)
 
 		state.Put("instance_definition", *instancePrototypeModel)
+		return doCreate(svc, instancePrototypeModel)
+	}
 
-		createInstanceOptions := vpcService.NewCreateInstanceOptions(
-			instancePrototypeModel,
-		)
-		instanceData, _, err := vpcService.CreateInstance(createInstanceOptions)
-		// End
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error creating the instance: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			// log.Fatalf(err.Error())
-			return multistep.ActionHalt
-		}
-
-		state.Put("instance_data", instanceData)
-
-		ui.Say("Instance successfully created!")
-		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
-		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
-	} else if vsiBootVolumeID != "" {
-		ui.Say("Creating instance with boot volume ID")
+	if vsiBootVolumeID != "" {
 		volumeIdentity := &vpcv1.VolumeIdentity{
 			ID: &vsiBootVolumeID,
 		}
@@ -223,57 +205,16 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		}
 		instancePrototypeModel.VolumeAttachments = dataVolumeAttachments(&config)
 
-		userDataFilePath := config.VSIUserDataFile
-		userDataString := config.VSIUserDataString
-		if userDataFilePath != "" {
-			content, err := os.ReadFile(userDataFilePath)
-			if err != nil {
-				err := fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-			instancePrototypeModel.UserData = &[]string{string(content)}[0]
-		} else if userDataString != "" {
-			instancePrototypeModel.UserData = &[]string{string(userDataString)}[0]
+		if err := applyUserData(&config, &instancePrototypeModel.UserData); err != nil {
+			return nil, err
 		}
-
-		if config.ResourceGroupID != "" {
-			instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-				ID: &config.ResourceGroupID,
-			}
-		} else if config.ResourceGroupName != "" {
-			derivedResourceGroupId := state.Get("derived_resource_group_id")
-			if derivedResourceGroupId != nil && derivedResourceGroupId.(string) != "" {
-				derivedResourceGroupIdStr := derivedResourceGroupId.(string)
-				instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
-					ID: &derivedResourceGroupIdStr,
-				}
-			}
-		}
+		instancePrototypeModel.ResourceGroup = resourceGroupIdentity(&config, state)
 
 		state.Put("instance_definition", *instancePrototypeModel)
+		return doCreate(svc, instancePrototypeModel)
+	}
 
-		createInstanceOptions := vpcService.NewCreateInstanceOptions(
-			instancePrototypeModel,
-		)
-		instanceData, _, err := vpcService.CreateInstance(createInstanceOptions)
-		// End
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error creating the instance: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			// log.Fatalf(err.Error())
-			return multistep.ActionHalt
-		}
-
-		state.Put("instance_data", instanceData)
-
-		ui.Say("Instance successfully created with the provided boot volume!")
-		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
-		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
-	} else if vsiBootSnapshotId != "" {
-		ui.Say("Creating instance with boot snapshot ID")
+	if vsiBootSnapshotId != "" {
 		sourceSnapshot := &vpcv1.SnapshotIdentity{
 			ID: &vsiBootSnapshotId,
 		}
@@ -291,21 +232,11 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		}
 		instancePrototypeModel.VolumeAttachments = dataVolumeAttachments(&config)
 
-		userDataFilePath := config.VSIUserDataFile
-		userDataString := config.VSIUserDataString
-		if userDataFilePath != "" {
-			content, err := os.ReadFile(userDataFilePath)
-			if err != nil {
-				err := fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-			instancePrototypeModel.UserData = &[]string{string(content)}[0]
-		} else if userDataString != "" {
-			instancePrototypeModel.UserData = &[]string{string(userDataString)}[0]
+		if err := applyUserData(&config, &instancePrototypeModel.UserData); err != nil {
+			return nil, err
 		}
-
+		// The snapshot path only supports resource_group_id (no
+		// resource_group_name derivation, unlike the other source paths).
 		if config.ResourceGroupID != "" {
 			instancePrototypeModel.ResourceGroup = &vpcv1.ResourceGroupIdentityByID{
 				ID: &config.ResourceGroupID,
@@ -313,36 +244,16 @@ func (step *stepCreateInstance) Run(_ context.Context, state multistep.StateBag)
 		}
 
 		state.Put("instance_definition", *instancePrototypeModel)
-
-		createInstanceOptions := vpcService.NewCreateInstanceOptions(
-			instancePrototypeModel,
-		)
-		instanceData, _, err := vpcService.CreateInstance(createInstanceOptions)
-		// End
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error creating the instance: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			// log.Fatalf(err.Error())
-			return multistep.ActionHalt
-		}
-
-		state.Put("instance_data", instanceData)
-
-		ui.Say("Instance successfully created with the provided boot snapshot!")
-		ui.Say(fmt.Sprintf("Instance's Name: %s", *instanceData.Name))
-		ui.Say(fmt.Sprintf("Instance's ID: %s", *instanceData.ID))
+		return doCreate(svc, instancePrototypeModel)
 	}
-	return multistep.ActionContinue
+
+	return nil, fmt.Errorf("[ERROR] no instance source configured")
 }
 
 func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 	config := state.Get("config").(Config)
 	ui := state.Get("ui").(packer.Ui)
-	var vpcService *vpcv1.VpcV1
-	if state.Get("vpcService") != nil {
-		vpcService = state.Get("vpcService").(*vpcv1.VpcV1)
-	}
+	svc := vpcService(state)
 
 	// Delete Floating IP if it was created (VSI Interface was set as public)
 	if config.VSIInterface == "public" {
@@ -352,8 +263,8 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 
 			floatingIPID := state.Get("floating_ip_id").(string)
 
-			options := vpcService.NewGetFloatingIPOptions(floatingIPID)
-			floatingIPresponse, response, err := vpcService.GetFloatingIP(options)
+			options := svc.NewGetFloatingIPOptions(floatingIPID)
+			floatingIPresponse, response, err := svc.GetFloatingIP(options)
 			if err != nil && response.StatusCode != 404 {
 				err := fmt.Errorf("[ERROR] Error getting the Floating IP: %s", err)
 				state.Put("error", err)
@@ -365,8 +276,8 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 			if response.StatusCode != 404 && floatingIPresponse.Status != nil {
 				status := floatingIPresponse.Status
 				if *status == "available" {
-					options := vpcService.NewDeleteFloatingIPOptions(floatingIPID)
-					result, err := vpcService.DeleteFloatingIP(options)
+					options := svc.NewDeleteFloatingIPOptions(floatingIPID)
+					result, err := svc.DeleteFloatingIP(options)
 
 					if err != nil {
 						err := fmt.Errorf("[ERROR] Error releasing the Floating IP. Please release it manually: %s", err)
@@ -388,41 +299,14 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 	// Wait a couple of seconds before attempting to delete the instance.
 	time.Sleep(2 * time.Second)
 
-	// Check if instance_data exists in state before attempting deletion
+	// A capacity-fallback attempt clears instance_data after deleting its failed
+	// VSI, so this only fires for the instance still standing at cleanup.
 	if state.Get("instance_data") != nil {
 		instanceData := state.Get("instance_data").(*vpcv1.Instance)
-		instanceID := *instanceData.ID
-		ui.Say(fmt.Sprintf("Deleting Instance ID: %s ...", instanceID))
-
-		options := &vpcv1.DeleteInstanceOptions{}
-		options.SetID(instanceID)
-		_, err := vpcService.DeleteInstance(options)
-
-		if err != nil {
-			err := fmt.Errorf("[ERROR] Error deleting the instance. Please delete it manually: %s", err)
+		if err := deleteInstanceAndWait(svc, ui, *instanceData.ID, config.StateTimeout); err != nil {
 			state.Put("error", err)
 			ui.Error(err.Error())
-			// log.Fatalf(err.Error())
 			return
-		}
-		instanceDeleted := false
-		for !instanceDeleted {
-			options := &vpcv1.GetInstanceOptions{}
-			options.SetID(instanceID)
-			instance, response, err := vpcService.GetInstance(options)
-			if err != nil {
-				if response != nil && response.StatusCode == 404 {
-					ui.Say("Instance deleted Successfully")
-					instanceDeleted = true
-					break
-				}
-				err := fmt.Errorf("[ERROR] Error getting the instance to check delete status. %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-			} else if instance != nil {
-				ui.Say(fmt.Sprintf("Instance status :-  %s", *instance.Status))
-			}
-			time.Sleep(10 * time.Second)
 		}
 	}
 
@@ -434,7 +318,7 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 		sgRuleOptions := &vpcv1.DeleteSecurityGroupRuleOptions{}
 		sgRuleOptions.SetSecurityGroupID(securityGroupID)
 		sgRuleOptions.SetID(ruleID)
-		sgRuleResponse, sgRuleErr := vpcService.DeleteSecurityGroupRule(sgRuleOptions)
+		sgRuleResponse, sgRuleErr := svc.DeleteSecurityGroupRule(sgRuleOptions)
 
 		if sgRuleErr != nil {
 			// Check if it's a 404 (resource already deleted)
@@ -463,7 +347,7 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 			ui.Say(fmt.Sprintf("Deleting Security Group %s ...", securityGroupName))
 			sgOptions := &vpcv1.DeleteSecurityGroupOptions{}
 			sgOptions.SetID(securityGroupID)
-			sgResponse, err := vpcService.DeleteSecurityGroup(sgOptions)
+			sgResponse, err := svc.DeleteSecurityGroup(sgOptions)
 			if err != nil {
 				// Check if it's a 404 (resource already deleted)
 				if sgResponse != nil && sgResponse.StatusCode == 404 {
@@ -481,6 +365,93 @@ func (step *stepCreateInstance) Cleanup(state multistep.StateBag) {
 		}
 	}
 
+}
+
+// vpcService returns the shared vpcv1 client from build state, or nil if it has
+// not been created yet.
+func vpcService(state multistep.StateBag) *vpcv1.VpcV1 {
+	if svc := state.Get("vpcService"); svc != nil {
+		return svc.(*vpcv1.VpcV1)
+	}
+	return nil
+}
+
+// doCreate issues the CreateInstance call for a built prototype, wrapping the
+// error consistently across the create paths.
+func doCreate(svc *vpcv1.VpcV1, prototype vpcv1.InstancePrototypeIntf) (*vpcv1.Instance, error) {
+	instanceData, _, err := svc.CreateInstance(svc.NewCreateInstanceOptions(prototype))
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Error creating the instance: %s", err)
+	}
+	return instanceData, nil
+}
+
+// applyUserData sets *dst from vsi_user_data_file or vsi_user_data (mutually
+// exclusive per Config.Prepare). It is a no-op when neither is configured.
+func applyUserData(config *Config, dst **string) error {
+	if config.VSIUserDataFile != "" {
+		content, err := os.ReadFile(config.VSIUserDataFile)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error reading user data file. Error: %s", err)
+		}
+		*dst = &[]string{string(content)}[0]
+		return nil
+	}
+	if config.VSIUserDataString != "" {
+		*dst = &[]string{config.VSIUserDataString}[0]
+	}
+	return nil
+}
+
+// resourceGroupIdentity resolves the resource group for the instance from
+// resource_group_id, or from the id derived from resource_group_name in
+// stepVerifyInput. Returns nil when neither is configured (the account default
+// resource group is then used).
+func resourceGroupIdentity(config *Config, state multistep.StateBag) vpcv1.ResourceGroupIdentityIntf {
+	if config.ResourceGroupID != "" {
+		return &vpcv1.ResourceGroupIdentityByID{ID: &config.ResourceGroupID}
+	}
+	if config.ResourceGroupName != "" {
+		if derived := state.Get("derived_resource_group_id"); derived != nil && derived.(string) != "" {
+			id := derived.(string)
+			return &vpcv1.ResourceGroupIdentityByID{ID: &id}
+		}
+	}
+	return nil
+}
+
+// deleteInstanceAndWait deletes the instance and blocks until the API reports it
+// gone (404), bounded by timeout. It is used both to tear down the successful
+// builder VSI at cleanup and to remove a VSI that failed to start before the
+// capacity fallback tries the next subnet. A transient status-check failure is
+// tolerated and retried until the deadline rather than aborting the delete —
+// which, on the fallback path, would abort the whole build over one API blip.
+func deleteInstanceAndWait(svc *vpcv1.VpcV1, ui packer.Ui, instanceID string, timeout time.Duration) error {
+	ui.Say(fmt.Sprintf("Deleting Instance ID: %s ...", instanceID))
+	options := &vpcv1.DeleteInstanceOptions{}
+	options.SetID(instanceID)
+	if _, err := svc.DeleteInstance(options); err != nil {
+		return fmt.Errorf("[ERROR] Error deleting the instance. Please delete it manually: %s", err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		getOptions := &vpcv1.GetInstanceOptions{}
+		getOptions.SetID(instanceID)
+		instance, response, err := svc.GetInstance(getOptions)
+		if err != nil {
+			if response != nil && response.StatusCode == 404 {
+				ui.Say("Instance deleted Successfully")
+				return nil
+			}
+			ui.Say(fmt.Sprintf("Instance status check failed, retrying: %s", err))
+		} else if instance != nil {
+			ui.Say(fmt.Sprintf("Instance status :-  %s", *instance.Status))
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("[ERROR] Timed out waiting for instance %s to delete. Please verify it was removed manually.", instanceID)
+		}
+		time.Sleep(defaultPollInterval)
+	}
 }
 
 func bootVolumePrototype(config *Config) *vpcv1.VolumePrototypeInstanceByImageContext {

--- a/builder/ibmcloud/vpc/step_get_subnet_info.go
+++ b/builder/ibmcloud/vpc/step_get_subnet_info.go
@@ -3,55 +3,91 @@ package vpc
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
+// subnetZone pairs a subnet id with the zone it lives in. stepCreateInstance
+// walks the slice (already shuffled here) creating the builder VSI in each
+// subnet's zone until one starts (see the capacity fallback there).
+type subnetZone struct {
+	ID   string
+	Zone string
+}
+
 type stepGetSubnetInfo struct{}
 
 func (s *stepGetSubnetInfo) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	config := state.Get("config").(Config)
+	svc := vpcService(state)
 
-	var vpcService *vpcv1.VpcV1
-	if state.Get("vpcService") != nil {
-		vpcService = state.Get("vpcService").(*vpcv1.VpcV1)
+	// config.SubnetIDs is the normalized list; a lone subnet_id became a
+	// one-element list in Config.Prepare.
+	subnets := make([]subnetZone, 0, len(config.SubnetIDs))
+	var vpcID string
+	for _, subnetID := range config.SubnetIDs {
+		ui.Say(fmt.Sprintf("Retrieving Subnet %s information...", subnetID))
+
+		options := &vpcv1.GetSubnetOptions{}
+		options.SetID(subnetID)
+		subnetData, _, err := svc.GetSubnet(options)
+		if err != nil {
+			err := fmt.Errorf("[ERROR] Error fetching subnet %s: %s", subnetID, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		if subnetData.VPC == nil || subnetData.VPC.ID == nil || subnetData.Zone == nil || subnetData.Zone.Name == nil {
+			err := fmt.Errorf("[ERROR] Subnet %s is missing VPC or zone information", subnetID)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		// All subnets must share one VPC: the VPC identity and the security group
+		// are fixed for the build, so a subnet in a different VPC could not serve
+		// as a fallback.
+		subnetVPC := *subnetData.VPC.ID
+		if vpcID == "" {
+			vpcID = subnetVPC
+		} else if subnetVPC != vpcID {
+			err := fmt.Errorf("[ERROR] All subnets must belong to the same VPC; subnet %s is in VPC %s but an earlier subnet is in VPC %s", subnetID, subnetVPC, vpcID)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		zone := *subnetData.Zone.Name
+		subnets = append(subnets, subnetZone{ID: subnetID, Zone: zone})
+		ui.Say(fmt.Sprintf("Subnet %s is in zone %s", subnetID, zone))
 	}
 
-	ui.Say(fmt.Sprintf("Retrieving Subnet %s information...", config.SubnetID))
-
-	options := &vpcv1.GetSubnetOptions{}
-	options.SetID(config.SubnetID)
-	subnetData, _, err := vpcService.GetSubnet(options)
-
-	if err != nil {
-		err := fmt.Errorf("[ERROR] Error fetching subnet %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
-	vpcId := *subnetData.VPC.ID
 	if config.SecurityGroupID != "" { // User provided security group
 		secGrpVPC := state.Get("user_sec_grp_vpc")
-		ui.Say("Verifying the security group and subnet belongs to same VPC..")
-		if vpcId != secGrpVPC {
-			err := fmt.Errorf("The security group and subnet provided are not connected to the same VPC id: %s", vpcId)
+		ui.Say("Verifying the security group and subnets belong to the same VPC..")
+		if vpcID != secGrpVPC {
+			err := fmt.Errorf("The security group and subnets provided are not connected to the same VPC id: %s", vpcID)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 	}
-	zone := *subnetData.Zone.Name
 
-	state.Put("vpc_id", vpcId)
-	state.Put("zone", zone)
+	// Try the subnets in a random order so repeated builds spread their baseline
+	// load across zones instead of always starting in the same one (which itself
+	// drives capacity pressure). Capacity fallback still walks the whole list.
+	rand.Shuffle(len(subnets), func(i, j int) { subnets[i], subnets[j] = subnets[j], subnets[i] })
+
+	state.Put("vpc_id", vpcID)
+	state.Put("bake_subnets", subnets)
 
 	ui.Say("Subnet Information successfully retrieved ...")
-	ui.Say(fmt.Sprintf("VPC ID: %s", vpcId))
-	ui.Say(fmt.Sprintf("Zone: %s", zone))
+	ui.Say(fmt.Sprintf("VPC ID: %s", vpcID))
 
 	return multistep.ActionContinue
 }

--- a/builder/ibmcloud/vpc/step_get_subnet_info_test.go
+++ b/builder/ibmcloud/vpc/step_get_subnet_info_test.go
@@ -1,0 +1,98 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type subnetInfo struct{ vpc, zone string }
+
+// subnetHandler serves GET /v1/subnets/{id} from a fixed catalog, so a test can
+// drive stepGetSubnetInfo over several subnets with controlled VPC/zone values.
+func subnetHandler(catalog map[string]subnetInfo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		info, ok := catalog[path.Base(r.URL.Path)]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"subnet not found"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"id":%q,"vpc":{"id":%q},"zone":{"name":%q},"status":"available"}`,
+			path.Base(r.URL.Path), info.vpc, info.zone)
+	}
+}
+
+func newSubnetInfoState(t *testing.T, url string, subnetIDs ...string) *multistep.BasicStateBag {
+	t.Helper()
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packer.TestUi(t))
+	state.Put("vpcService", newTestVpcService(t, url))
+	state.Put("config", Config{SubnetIDs: subnetIDs})
+	return state
+}
+
+// TestStepGetSubnetInfoSameVPC covers the multi-subnet golden path: every subnet
+// resolves, they share a VPC, and bake_subnets is populated with each subnet's
+// zone (order is shuffled, so it's compared as a set).
+func TestStepGetSubnetInfoSameVPC(t *testing.T) {
+	srv := httptest.NewServer(subnetHandler(map[string]subnetInfo{
+		"0717-a": {vpc: "vpc-1", zone: "us-east-1"},
+		"0727-b": {vpc: "vpc-1", zone: "us-east-2"},
+	}))
+	defer srv.Close()
+
+	state := newSubnetInfoState(t, srv.URL, "0717-a", "0727-b")
+
+	step := &stepGetSubnetInfo{}
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Run action = %v, want ActionContinue (err=%v)", action, state.Get("error"))
+	}
+	if got := state.Get("vpc_id"); got != "vpc-1" {
+		t.Errorf("vpc_id = %v, want vpc-1", got)
+	}
+	bake, ok := state.Get("bake_subnets").([]subnetZone)
+	if !ok || len(bake) != 2 {
+		t.Fatalf("bake_subnets = %v, want 2 entries", state.Get("bake_subnets"))
+	}
+	gotZones := map[string]string{}
+	for _, sz := range bake {
+		gotZones[sz.ID] = sz.Zone
+	}
+	for id, wantZone := range map[string]string{"0717-a": "us-east-1", "0727-b": "us-east-2"} {
+		if gotZones[id] != wantZone {
+			t.Errorf("subnet %s zone = %q, want %q", id, gotZones[id], wantZone)
+		}
+	}
+}
+
+// TestStepGetSubnetInfoRejectsCrossVPC pins the same-VPC guard: a second subnet
+// in a different VPC halts the build, since the VPC identity and security group
+// are fixed and a cross-VPC subnet can't serve as a fallback.
+func TestStepGetSubnetInfoRejectsCrossVPC(t *testing.T) {
+	srv := httptest.NewServer(subnetHandler(map[string]subnetInfo{
+		"0717-a": {vpc: "vpc-1", zone: "us-east-1"},
+		"0727-b": {vpc: "vpc-2", zone: "us-east-2"},
+	}))
+	defer srv.Close()
+
+	state := newSubnetInfoState(t, srv.URL, "0717-a", "0727-b")
+
+	step := &stepGetSubnetInfo{}
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("Run action = %v, want ActionHalt", action)
+	}
+	err, _ := state.Get("error").(error)
+	if err == nil || !strings.Contains(err.Error(), "same VPC") {
+		t.Fatalf("error = %v, want it to mention same VPC", err)
+	}
+}

--- a/examples/build.vpc.subnet.fallback.pkr.hcl
+++ b/examples/build.vpc.subnet.fallback.pkr.hcl
@@ -1,0 +1,61 @@
+packer {
+  required_plugins {
+    ibmcloud = {
+      version = ">=v3.0.0"
+      source  = "github.com/IBM/ibmcloud"
+    }
+  }
+}
+
+variable "ibm_api_key" {
+  type    = string
+  default = ""
+}
+
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+}
+
+# Multi-subnet capacity fallback: supply several candidate subnets (one per zone,
+# all in the same VPC). The builder tries them in a random order and moves on to
+# the next when a zone has no host capacity for vsi_profile
+# (a "cannot_start_capacity" failure). Use this instead of subnet_id when the
+# builder profile is scarce in a single zone. Provide exactly one of subnet_id or
+# subnet_ids.
+source "ibmcloud-vpc" "centos" {
+  api_key = "${var.ibm_api_key}"
+  region  = "us-east"
+
+  subnet_ids = [
+    "0757-4ad0af5f-8084-469d-a10e-49c444caa312", # us-east-1
+    "0767-1b2c3d4e-5f60-7182-93a4-b5c6d7e8f901", # us-east-2
+    "0777-9a8b7c6d-5e4f-3021-8f9e-1d2c3b4a5968", # us-east-3
+  ]
+  resource_group_id = "1984ce401571473492918ea987dd1e6f"
+  security_group_id = ""
+
+  vsi_base_image_name = "ibm-centos-stream-10-amd64-2"
+  vsi_profile         = "bx2-2x8"
+  vsi_interface       = "public"
+  image_name          = "packer-${local.timestamp}"
+
+  communicator = "ssh"
+  ssh_username = "root"
+  ssh_port     = 22
+  ssh_timeout  = "15m"
+
+  timeout = "30m"
+}
+
+build {
+  sources = [
+    "source.ibmcloud-vpc.centos"
+  ]
+
+  provisioner "shell" {
+    execute_command = "{{.Vars}} bash '{{.Path}}'"
+    inline = [
+      "echo 'Hello from IBM Cloud Packer Plugin - VPC Infrastructure.'",
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds an optional `subnet_ids` list to the VPC builder. When set, the builder tries each candidate subnet in turn and falls through to the next when a zone cannot place the builder instance for a capacity reason. The existing scalar `subnet_id` is unchanged.

## Motivation

The builder pins a single subnet, and therefore a single zone. When that zone has no host capacity for the builder instance's profile, the instance is created but goes to `failed` with a `cannot_start_capacity` (or related host-placement) status reason, and the build aborts with no fallback. For scarce or large profiles this is a frequent, unrecoverable failure. `subnet_ids` lets a build provide several candidate subnets (one per zone) so it can retry placement in another zone instead of failing.

## Behavior

- `subnet_ids` (list) and `subnet_id` (string) are mutually exclusive; exactly one is required. A lone `subnet_id` is normalized to a one-element list internally, so all existing configurations behave identically.
- All candidate subnets must belong to the same VPC (the VPC identity and security group are fixed for the build); this is validated up front.
- The builder tries the subnets in a random order (to spread baseline load across zones) and, on a capacity/host-placement failure, deletes the failed instance and advances to the next subnet. Non-capacity failures (auth, quota, validation) fail fast without retrying.
- Only instance-start status reasons classified as capacity/host-placement (`cannot_start_capacity`, `cannot_start_compute`, `cannot_start_placement_group`, `cannot_start_reservation_capacity`) trigger fallback.

## Implementation notes

- Instance-"failed" status reasons are classified into a retryable capacity error vs. a fatal error; the create step loops over candidate subnets accordingly. The delete-and-wait for a failed instance is bounded by the configured timeout.
- Refactors the four instance-source paths (catalog / image / boot volume / boot snapshot) to share helpers for user-data, resource-group resolution, and instance creation, removing prior duplication. (The snapshot path's existing resource-group behavior is preserved.)
- Also hardens the "failed" status-reason handling against an empty status-reason slice (previously an unchecked index).

## Backward compatibility

Existing `subnet_id` configurations are unaffected — `subnet_id` remains supported and is normalized internally to the list form.

## Testing

- **Unit tests:** config validation (mutual exclusion, empty-entry rejection, `subnet_id` normalization) and capacity-vs-fatal status-reason classification, including multi-reason and nil-code cases. `go build`, `go vet`, and the full package test suite pass.
- **End-to-end against real IBM VPC:** built the plugin and ran a complete VPC image build configured with three candidate subnets spanning three zones in one region. The first zone returned `cannot_start_capacity` at instance start; the builder deleted the failed instance, advanced to the next subnet, and the instance started successfully in another zone — after which SSH provisioning and the rest of the build proceeded normally. This exercised the fallback path against a genuine (not simulated) capacity shortfall.

## Docs / examples

- README documents `subnet_ids`.
- Adds `examples/build.vpc.subnet.fallback.pkr.hcl`.
